### PR TITLE
Add files for starport usages #9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ docker-compose.yml
 
 artifacts
 build
+release

--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,32 @@
+accounts:
+  - name: alice
+    coins: ["100000000000nanolike"]
+  - name: bob
+    coins: ["100000000000nanolike"]
+validator:
+  name: alice
+  staked: "10000000000nanolike"
+faucet:
+  name: bob
+  coins: ["100000000000nanolike"]
+build:
+  binary: "liked"
+init:
+  home: "$HOME/.liked"
+genesis:
+  chain_id: "likecoin-local-1"
+  app_state:
+    staking:
+      params:
+        bond_denom: "nanolike"
+    mint:
+      params:
+        mint_denom: "nanolike"
+    crisis:
+      constant_fee:
+        denom: "nanolike"
+    gov:
+      deposit_params:
+        min_deposit:
+          - amount: "1000000000"
+            denom: "nanolike"


### PR DESCRIPTION
Ref #9

- Add config.yml ([ref gaia](https://github.com/cosmos/gaia/blob/main/config.yml), [ref evmos](https://github.com/tharsis/evmos/blob/main/config.yml))
- Update gitignore to ignore `release` folder in case user use starport to build instead of makefile

Testing done:
- Tested `starport chain serve` 
- Tested `starport chain build`
- Tested `starport chain faucet`