### PR TITLE
Add missing test util for starport scaffold feature #9

### DIFF
--- a/testutil/network/network.go
+++ b/testutil/network/network.go
@@ -1,0 +1,78 @@
+package network
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	"github.com/cosmos/cosmos-sdk/crypto/hd"
+	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+	servertypes "github.com/cosmos/cosmos-sdk/server/types"
+	"github.com/cosmos/cosmos-sdk/simapp"
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	"github.com/cosmos/cosmos-sdk/testutil/network"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	tmrand "github.com/tendermint/tendermint/libs/rand"
+	tmdb "github.com/tendermint/tm-db"
+
+	"github.com/likecoin/likechain/app"
+)
+
+type (
+	Network = network.Network
+	Config  = network.Config
+)
+
+// New creates instance with fully configured cosmos network.
+// Accepts optional config, that will be used in place of the DefaultConfig() if provided.
+func New(t *testing.T, configs ...network.Config) *network.Network {
+	if len(configs) > 1 {
+		panic("at most one config should be provided")
+	}
+	var cfg network.Config
+	if len(configs) == 0 {
+		cfg = DefaultConfig()
+	} else {
+		cfg = configs[0]
+	}
+	net := network.New(t, cfg)
+	t.Cleanup(net.Cleanup)
+	return net
+}
+
+// DefaultConfig will initialize config for the network with custom application,
+// genesis and single validator. All other parameters are inherited from cosmos-sdk/testutil/network.DefaultConfig
+func DefaultConfig() network.Config {
+	encoding := app.MakeEncodingConfig()
+	return network.Config{
+		Codec:             encoding.Codec,
+		TxConfig:          encoding.TxConfig,
+		LegacyAmino:       encoding.Amino,
+		InterfaceRegistry: encoding.InterfaceRegistry,
+		AccountRetriever:  authtypes.AccountRetriever{},
+		AppConstructor: func(val network.Validator) servertypes.Application {
+			return app.NewLikeApp(
+				val.Ctx.Logger, tmdb.NewMemDB(), nil, true, map[int64]bool{}, val.Ctx.Config.RootDir, 0,
+				encoding,
+				simapp.EmptyAppOptions{},
+				baseapp.SetPruning(storetypes.NewPruningOptionsFromString(val.AppConfig.Pruning)),
+				baseapp.SetMinGasPrices(val.AppConfig.MinGasPrices),
+			)
+		},
+		GenesisState:    app.ModuleBasics.DefaultGenesis(encoding.Codec),
+		TimeoutCommit:   2 * time.Second,
+		ChainID:         "chain-" + tmrand.NewRand().Str(6),
+		NumValidators:   1,
+		BondDenom:       sdk.DefaultBondDenom,
+		MinGasPrices:    fmt.Sprintf("0.000006%s", sdk.DefaultBondDenom),
+		AccountTokens:   sdk.TokensFromConsensusPower(1000, sdk.DefaultPowerReduction),
+		StakingTokens:   sdk.TokensFromConsensusPower(500, sdk.DefaultPowerReduction),
+		BondedTokens:    sdk.TokensFromConsensusPower(100, sdk.DefaultPowerReduction),
+		PruningStrategy: storetypes.PruningOptionNothing,
+		CleanupDir:      true,
+		SigningAlgo:     string(hd.Secp256k1Type),
+		KeyringOptions:  []keyring.Option{},
+	}
+}

--- a/testutil/nullify/nullify.go
+++ b/testutil/nullify/nullify.go
@@ -1,0 +1,57 @@
+// Package nullify provides methods to init nil values structs for test assertion.
+package nullify
+
+import (
+	"reflect"
+	"unsafe"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+var (
+	coinType  = reflect.TypeOf(sdk.Coin{})
+	coinsType = reflect.TypeOf(sdk.Coins{})
+)
+
+// Fill analyze all struct fields and slices with
+// reflection and initialize the nil and empty slices,
+// structs, and pointers.
+func Fill(x interface{}) interface{} {
+	v := reflect.Indirect(reflect.ValueOf(x))
+	switch v.Kind() {
+	case reflect.Slice:
+		for i := 0; i < v.Len(); i++ {
+			obj := v.Index(i)
+			objPt := reflect.NewAt(obj.Type(), unsafe.Pointer(obj.UnsafeAddr())).Interface()
+			objPt = Fill(objPt)
+			obj.Set(reflect.ValueOf(objPt))
+		}
+	case reflect.Struct:
+		for i := 0; i < v.NumField(); i++ {
+			f := reflect.Indirect(v.Field(i))
+			if !f.CanSet() {
+				continue
+			}
+			switch f.Kind() {
+			case reflect.Slice:
+				f.Set(reflect.MakeSlice(f.Type(), 0, 0))
+			case reflect.Struct:
+				switch f.Type() {
+				case coinType:
+					coin := reflect.New(coinType).Interface()
+					s := reflect.ValueOf(coin).Elem()
+					f.Set(s)
+				case coinsType:
+					coins := reflect.New(coinsType).Interface()
+					s := reflect.ValueOf(coins).Elem()
+					f.Set(s)
+				default:
+					objPt := reflect.NewAt(f.Type(), unsafe.Pointer(f.UnsafeAddr())).Interface()
+					s := Fill(objPt)
+					f.Set(reflect.ValueOf(s))
+				}
+			}
+		}
+	}
+	return reflect.Indirect(v).Interface()
+}

--- a/testutil/sample/sample.go
+++ b/testutil/sample/sample.go
@@ -1,0 +1,13 @@
+package sample
+
+import (
+	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// AccAddress returns a sample account address
+func AccAddress() string {
+	pk := ed25519.GenPrivKey().PubKey()
+	addr := pk.Address()
+	return sdk.AccAddress(addr).String()
+}


### PR DESCRIPTION
Ref oursky/likecoin-chain#9, found during oursky/likecoin-chain#11

Patch so that `starport scaffold ...` works

Files obtained from scaffolding a dummy chain with starport, or generated while using starport scaffold