### PR TITLE
Multiple fixes to migration handler for v2.0.0

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -448,7 +448,6 @@ func (app *LikeApp) registerUpgradeHandlers() {
 			"slashing":     1,
 			"staking":      1,
 			"upgrade":      1,
-			"vesting":      1,
 			"ibc":          1,
 			"genutil":      1,
 			"transfer":     1,
@@ -465,7 +464,7 @@ func (app *LikeApp) registerUpgradeHandlers() {
 
 	if upgradeInfo.Name == "v2.0.0" && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
 		storeUpgrades := storetypes.StoreUpgrades{
-			Added: []string{"authz", "feegrant"},
+			// No added, renamed or removed stores
 		}
 
 		// configure store loader that checks if version == upgradeHeight and applies store upgrades

--- a/app/app.go
+++ b/app/app.go
@@ -488,6 +488,8 @@ func (app *LikeApp) InitChainer(ctx sdk.Context, req abci.RequestInitChain) abci
 	var genesisState map[string]json.RawMessage
 	app.cdc.MustUnmarshalJSON(req.AppStateBytes, &genesisState)
 
+	app.UpgradeKeeper.SetModuleVersionMap(ctx, app.mm.GetVersionMap())
+
 	return app.mm.InitGenesis(ctx, app.appCodec, genesisState)
 }
 


### PR DESCRIPTION
Ref oursky/likecoin-chain#49, oursky/likecoin-chain#20
Follow up oursky/likecoin-chain#21 

Related docs:
- https://docs.cosmos.network/master/core/upgrade.html
- https://docs.cosmos.network/master/migrations/chain-upgrade-guide-044.html#chain-upgrade

Changes:
- Add missing upgrade keeper call at chain init
- Fix upgrade handler not reflecting modules used by likecoin