### PR TITLE
Include the go Makefile content at deploy makefile

### DIFF
--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -1,6 +1,8 @@
 STACK ?= validator
 CLOUD ?= azure
 
+include ./cmd/deploy/assets/Makefile
+
 .PHONY: setup-pulumi
 setup-pulumi:
 	pulumi stack init $(STACK)


### PR DESCRIPTION
So the SETUP.md still works, and people plan to clone the repo and run
at their machine will works.