### PR TITLE
Fix typo and add ssh whitelist config to deployment makefile

### DIFF
--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -14,7 +14,7 @@ ssh-key:
 	pulumi config set -s $(STACK) \
 		likecoin-skynet:resource-group-name $(RESOURCE_GROUP)
 	pulumi config set -s $(STACK) \
-		like-skynet:vm-password --secret $(PASSWORD)
+		likecoin-skynet:vm-password --secret $(PASSWORD)
 	cat id_rsa.pub | pulumi config set likecoin-skynet:vm-public-key --
 	cat id_rsa | pulumi config set likecoin-skynet:vm-private-key --secret --
 

--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -14,6 +14,8 @@ ssh-key:
 	pulumi config set -s $(STACK) \
 		likecoin-skynet:resource-group-name $(RESOURCE_GROUP)
 	pulumi config set -s $(STACK) \
+		likecoin-skynet:vm-ssh-allow-list $(SSH_WHITELIST)
+	pulumi config set -s $(STACK) \
 		likecoin-skynet:vm-password --secret $(PASSWORD)
 	cat id_rsa.pub | pulumi config set likecoin-skynet:vm-public-key --
 	cat id_rsa | pulumi config set likecoin-skynet:vm-private-key --secret --

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -43,6 +43,9 @@ export CLOUD=azure
 export PROJECT_ID=likecoin-skynet
 export CLOUD=gcp
 
+# source cidr/ip addresses for ssh access, comma separated, default current ip address
+export SSH_WHITELIST=$(curl checkip.amazonaws.com)
+
 export PASSWORD=$(openssl rand -base64 48 | sed -e 's/[\/|=|+]//g')
 export STACK=validator
 echo $PASSWORD
@@ -74,6 +77,8 @@ make ssh-key
 ```
 
 We should now see the values being assigned in `Pulumi.$STACK.yaml`
+
+**NOTE: It is highly recommended to set a value for the config `vm-ssh-allow-list` to prevent global ssh access to the virtual machine. If any assigned ip address is dynamically allocated by the ISP, newly rotated ip address shall be updated on Azure Portal/Google Cloud Platform to maintain said ssh access.**
 
 ## Provision of resources
 


### PR DESCRIPTION
- Fixed typo for `likecoin-skynet:vm-password`
- Added instructions and config to setup ssh whitelist for vm access

refs #72 