### PR TITLE
Improve LikeNFT CLI UX

### DIFF
--- a/x/likenft/client/cli/query_classes_by_iscn.go
+++ b/x/likenft/client/cli/query_classes_by_iscn.go
@@ -11,8 +11,8 @@ import (
 
 func CmdListClassesByISCN() *cobra.Command {
 	cmd := &cobra.Command{
-		Short: "list all ISCN to NFT Class relations",
 		Use:   "index",
+		Short: "Enumerate all ISCN to NFT classes relation records",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx := client.GetClientContextFromCmd(cmd)
 
@@ -44,8 +44,8 @@ func CmdListClassesByISCN() *cobra.Command {
 
 func CmdShowClassesByISCN() *cobra.Command {
 	cmd := &cobra.Command{
-		Short: "list NFT classes related to an ISCN",
 		Use:   "classes [iscn-id-prefix]",
+		Short: "Query NFT classes related to an ISCN",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			clientCtx := client.GetClientContextFromCmd(cmd)

--- a/x/likenft/client/cli/query_classes_by_iscn.go
+++ b/x/likenft/client/cli/query_classes_by_iscn.go
@@ -11,8 +11,8 @@ import (
 
 func CmdListClassesByISCN() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "all-classes-by-iscn",
 		Short: "list all ISCN to NFT Class relations",
+		Use:   "index",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx := client.GetClientContextFromCmd(cmd)
 
@@ -44,8 +44,8 @@ func CmdListClassesByISCN() *cobra.Command {
 
 func CmdShowClassesByISCN() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "classes-by-iscn [iscn-id-prefix]",
 		Short: "list NFT classes related to an ISCN",
+		Use:   "classes [iscn-id-prefix]",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			clientCtx := client.GetClientContextFromCmd(cmd)

--- a/x/likenft/client/cli/query_iscn_by_class.go
+++ b/x/likenft/client/cli/query_iscn_by_class.go
@@ -13,8 +13,8 @@ var _ = strconv.Itoa(0)
 
 func CmdISCNByClass() *cobra.Command {
 	cmd := &cobra.Command{
-		Short: "Get latest ISCN record related to a NFT Class",
 		Use:   "iscn [class-id]",
+		Short: "Query latest ISCN record related to a NFT class",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			reqClassId := args[0]

--- a/x/likenft/client/cli/query_iscn_by_class.go
+++ b/x/likenft/client/cli/query_iscn_by_class.go
@@ -13,8 +13,8 @@ var _ = strconv.Itoa(0)
 
 func CmdISCNByClass() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "iscn-by-class [class-id]",
 		Short: "Get latest ISCN record related to a NFT Class",
+		Use:   "iscn [class-id]",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			reqClassId := args[0]

--- a/x/likenft/client/cli/query_params.go
+++ b/x/likenft/client/cli/query_params.go
@@ -12,7 +12,7 @@ import (
 func CmdQueryParams() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "params",
-		Short: "shows the parameters of the module",
+		Short: "Shows the parameters of the module",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx := client.GetClientContextFromCmd(cmd)

--- a/x/likenft/client/cli/read_json_file.go
+++ b/x/likenft/client/cli/read_json_file.go
@@ -17,3 +17,16 @@ func readCmdNewClassInput(path string) (*CmdNewClassInput, error) {
 	}
 	return &input, nil
 }
+
+func readCmdUpdateClassInput(path string) (*CmdUpdateClassInput, error) {
+	file, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	input := CmdUpdateClassInput{}
+	err = json.Unmarshal(file, &input)
+	if err != nil {
+		return nil, err
+	}
+	return &input, nil
+}

--- a/x/likenft/client/cli/read_json_file.go
+++ b/x/likenft/client/cli/read_json_file.go
@@ -30,3 +30,16 @@ func readCmdUpdateClassInput(path string) (*CmdUpdateClassInput, error) {
 	}
 	return &input, nil
 }
+
+func readCmdMintNFTInput(path string) (*CmdMintNFTInput, error) {
+	file, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	input := CmdMintNFTInput{}
+	err = json.Unmarshal(file, &input)
+	if err != nil {
+		return nil, err
+	}
+	return &input, nil
+}

--- a/x/likenft/client/cli/read_json_file.go
+++ b/x/likenft/client/cli/read_json_file.go
@@ -1,0 +1,19 @@
+package cli
+
+import (
+	"encoding/json"
+	"io/ioutil"
+)
+
+func readCmdNewClassInput(path string) (*CmdNewClassInput, error) {
+	file, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	input := CmdNewClassInput{}
+	err = json.Unmarshal(file, &input)
+	if err != nil {
+		return nil, err
+	}
+	return &input, nil
+}

--- a/x/likenft/client/cli/tx_burn_nft.go
+++ b/x/likenft/client/cli/tx_burn_nft.go
@@ -15,7 +15,7 @@ var _ = strconv.Itoa(0)
 func CmdBurnNFT() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "burn-nft [class-id] [nft-id]",
-		Short: "Broadcast message BurnNFT",
+		Short: "Burn a NFT. Only allowed when the class is configured to be burnable",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			argClassID := args[0]

--- a/x/likenft/client/cli/tx_mint_nft.go
+++ b/x/likenft/client/cli/tx_mint_nft.go
@@ -12,17 +12,33 @@ import (
 
 var _ = strconv.Itoa(0)
 
+type CmdMintNFTInput struct {
+	Uri      string          `json:"uri"`
+	UriHash  string          `json:"uriHash`
+	Metadata types.JsonInput `json:"metadata"`
+}
+
 func CmdMintNFT() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "mint-nft [class-id] [id] [uri] [uri-hash] [metadata]",
+		Use:   "mint-nft [class-id] [id] [json-file-input]",
 		Short: "Mint NFT under a class",
-		Args:  cobra.ExactArgs(5),
+		Example: `JSON file content:
+{
+	"uri": "",
+	"uriHash": "",
+	"metadata": {}
+}`,
+		Args: cobra.ExactArgs(3),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			argClassId := args[0]
 			argId := args[1]
-			argUri := args[2]
-			argUriHash := args[3]
-			argMetadata := args[4]
+			input, err := readCmdMintNFTInput(args[2])
+			if input == nil || err != nil {
+				return err
+			}
+			argUri := input.Uri
+			argUriHash := input.UriHash
+			argMetadata := input.Metadata
 
 			clientCtx, err := client.GetClientTxContext(cmd)
 			if err != nil {
@@ -35,7 +51,7 @@ func CmdMintNFT() *cobra.Command {
 				argId,
 				argUri,
 				argUriHash,
-				types.JsonInput(argMetadata),
+				argMetadata,
 			)
 			if err := msg.ValidateBasic(); err != nil {
 				return err

--- a/x/likenft/client/cli/tx_mint_nft.go
+++ b/x/likenft/client/cli/tx_mint_nft.go
@@ -15,7 +15,7 @@ var _ = strconv.Itoa(0)
 func CmdMintNFT() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "mint-nft [class-id] [id] [uri] [uri-hash] [metadata]",
-		Short: "Broadcast message MintNFT",
+		Short: "Mint NFT under a class",
 		Args:  cobra.ExactArgs(5),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			argClassId := args[0]

--- a/x/likenft/client/cli/tx_new_class.go
+++ b/x/likenft/client/cli/tx_new_class.go
@@ -12,24 +12,44 @@ import (
 
 var _ = strconv.Itoa(0)
 
+type CmdNewClassInput struct {
+	Name        string          `json:"name"`
+	Symbol      string          `json:"symbol"`
+	Description string          `json:"description"`
+	Uri         string          `json:"uri"`
+	UriHash     string          `json:"uriHash"`
+	Metadata    types.JsonInput `json:"metadata"`
+	Burnable    bool            `json:"burnable"`
+}
+
 func CmdNewClass() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "new-class [iscn-id-prefix] [name] [symbol] [description] [uri] [uri-hash] [metadata] [burnable]",
+		Use:   "new-class [iscn-id-prefix] [json-file]",
 		Short: "Create new NFT class related to an ISCN record",
-		Args:  cobra.ExactArgs(8),
+		Example: `JSON file content:
+{
+	"name": "",
+	"symbol": "",
+	"description": "",
+	"uri": "",
+	"uriHash": "",
+	"metadata": {},
+	"burnable": true
+}`,
+		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			argIscnIdPrefix := args[0]
-			argName := args[1]
-			argSymbol := args[2]
-			argDescription := args[3]
-			argUri := args[4]
-			argUriHash := args[5]
-			argMetadata := args[6]
-			argBurnable := args[7]
-			burnable, err := strconv.ParseBool(argBurnable)
-			if err != nil {
+			input, err := readCmdNewClassInput(args[1])
+			if input == nil || err != nil {
 				return err
 			}
+			argName := input.Name
+			argSymbol := input.Symbol
+			argDescription := input.Description
+			argUri := input.Uri
+			argUriHash := input.UriHash
+			argMetadata := input.Metadata
+			argBurnable := input.Burnable
 
 			clientCtx, err := client.GetClientTxContext(cmd)
 			if err != nil {
@@ -44,8 +64,8 @@ func CmdNewClass() *cobra.Command {
 				argDescription,
 				argUri,
 				argUriHash,
-				types.JsonInput(argMetadata),
-				burnable,
+				argMetadata,
+				argBurnable,
 			)
 			if err := msg.ValidateBasic(); err != nil {
 				return err

--- a/x/likenft/client/cli/tx_new_class.go
+++ b/x/likenft/client/cli/tx_new_class.go
@@ -15,7 +15,7 @@ var _ = strconv.Itoa(0)
 func CmdNewClass() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "new-class [iscn-id-prefix] [name] [symbol] [description] [uri] [uri-hash] [metadata] [burnable]",
-		Short: "Broadcast message NewClass",
+		Short: "Create new NFT class related to an ISCN record",
 		Args:  cobra.ExactArgs(8),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			argIscnIdPrefix := args[0]

--- a/x/likenft/client/cli/tx_update_class.go
+++ b/x/likenft/client/cli/tx_update_class.go
@@ -12,24 +12,44 @@ import (
 
 var _ = strconv.Itoa(0)
 
+type CmdUpdateClassInput struct {
+	Name        string          `json:"name"`
+	Symbol      string          `json:"symbol"`
+	Description string          `json:"description"`
+	Uri         string          `json:"uri"`
+	UriHash     string          `json:"uriHash"`
+	Metadata    types.JsonInput `json:"metadata"`
+	Burnable    bool            `json:"burnable"`
+}
+
 func CmdUpdateClass() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "update-class [class-id] [name] [symbol] [description] [uri] [uri-hash] [metadata] [burnable]",
+		Use:   "update-class [class-id] [json-file-input]",
 		Short: "Update existing nft class. Only allowed when there is no token minted",
-		Args:  cobra.ExactArgs(8),
+		Example: `JSON file content:
+{
+	"name": "",
+	"symbol": "",
+	"description": "",
+	"uri": "",
+	"uriHash": "",
+	"metadata": {},
+	"burnable": true
+}`,
+		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			argClassId := args[0]
-			argName := args[1]
-			argSymbol := args[2]
-			argDescription := args[3]
-			argUri := args[4]
-			argUriHash := args[5]
-			argMetadata := args[6]
-			argBurnable := args[7]
-			burnable, err := strconv.ParseBool(argBurnable)
-			if err != nil {
+			input, err := readCmdUpdateClassInput(args[1])
+			if input == nil || err != nil {
 				return err
 			}
+			argName := input.Name
+			argSymbol := input.Symbol
+			argDescription := input.Description
+			argUri := input.Uri
+			argUriHash := input.UriHash
+			argMetadata := input.Metadata
+			argBurnable := input.Burnable
 
 			clientCtx, err := client.GetClientTxContext(cmd)
 			if err != nil {
@@ -44,8 +64,8 @@ func CmdUpdateClass() *cobra.Command {
 				argDescription,
 				argUri,
 				argUriHash,
-				types.JsonInput(argMetadata),
-				burnable,
+				argMetadata,
+				argBurnable,
 			)
 			if err := msg.ValidateBasic(); err != nil {
 				return err

--- a/x/likenft/client/cli/tx_update_class.go
+++ b/x/likenft/client/cli/tx_update_class.go
@@ -15,7 +15,7 @@ var _ = strconv.Itoa(0)
 func CmdUpdateClass() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update-class [class-id] [name] [symbol] [description] [uri] [uri-hash] [metadata] [burnable]",
-		Short: "Broadcast message UpdateClass",
+		Short: "Update existing nft class. Only allowed when there is no token minted",
 		Args:  cobra.ExactArgs(8),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			argClassId := args[0]


### PR DESCRIPTION
Ref #14 

- Simplify command name
- Add missing descriptions
- Support json input for complex command (new class, update class, mint nft)

```sh
./build/liked query likenft
Querying commands for the likenft module

Usage:
  liked query likenft [flags]
  liked query likenft [command]

Available Commands:
  classes     Query NFT classes related to an ISCN
  index       Enumerate all ISCN to NFT classes relation records
  iscn        Query latest ISCN record related to a NFT class
  params      Shows the parameters of the module
```

Examples:
```sh
./build/liked tx likenft new-class
Error: accepts 2 arg(s), received 0
Usage:
  liked tx likenft new-class [iscn-id-prefix] [json-file] [flags]

Examples:
JSON file content:
{
	"name": "",
	"symbol": "",
	"description": "",
	"uri": "",
	"uriHash": "",
	"metadata": {},
	"burnable": true
}

./build/liked tx likenft update-class
Error: accepts 2 arg(s), received 0
Usage:
  liked tx likenft update-class [class-id] [json-file-input] [flags]

Examples:
JSON file content:
{
	"name": "",
	"symbol": "",
	"description": "",
	"uri": "",
	"uriHash": "",
	"metadata": {},
	"burnable": true
}

./build/liked tx likenft mint-nft
Error: accepts 3 arg(s), received 0
Usage:
  liked tx likenft mint-nft [class-id] [id] [json-file-input] [flags]

Examples:
JSON file content:
{
	"uri": "",
	"uriHash": "",
	"metadata": {}
}
```

Testing done:
- Tested commands locally