### PR TITLE
Update goreleaser cross image path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ release:
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v `pwd`:/go/src/$(NAME) \
 		-w /go/src/$(NAME) \
-		ghcr.io/troian/golang-cross:${GOLANG_CROSS_VERSION} \
+		ghcr.io/goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \
 		release --rm-dist --skip-validate
 
 .PHONY: release


### PR DESCRIPTION
Since go 1.18+ the goreleaser cross has been migrated to the goreleaser docker repo