### PR TITLE
Add bech32 prefix migration

### DIFF
--- a/bech32-migration/auth/auth.go
+++ b/bech32-migration/auth/auth.go
@@ -1,0 +1,44 @@
+package auth
+
+import (
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/cosmos/cosmos-sdk/x/auth/types"
+
+	"github.com/likecoin/likechain/bech32-migration/utils"
+)
+
+func MigrateAddressBech32(ctx sdk.Context, storeKey sdk.StoreKey, cdc codec.BinaryCodec) {
+	ctx.Logger().Info("Migration of address bech32 for auth module begin")
+	accountCount := uint64(0)
+	utils.IterateStoreByPrefix(ctx, storeKey, types.AddressStoreKeyPrefix, func(bz []byte) []byte {
+		var accountI types.AccountI
+		err := cdc.UnmarshalInterface(bz, &accountI)
+		if err != nil {
+			panic(err)
+		}
+		switch accountI.(type) {
+		case *types.BaseAccount:
+			{
+				acc := accountI.(*types.BaseAccount)
+				acc.Address = utils.ConvertAccAddr(acc.Address)
+			}
+		case *types.ModuleAccount:
+			{
+				acc := accountI.(*types.ModuleAccount)
+				acc.Address = utils.ConvertAccAddr(acc.Address)
+			}
+		}
+		bz, err = cdc.MarshalInterface(accountI)
+		if err != nil {
+			panic(err)
+		}
+		accountCount++
+		return bz
+	})
+	ctx.Logger().Info(
+		"Migration of address bech32 for auth module done",
+		"account_count", accountCount,
+	)
+}

--- a/bech32-migration/auth/auth.go
+++ b/bech32-migration/auth/auth.go
@@ -5,6 +5,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/cosmos/cosmos-sdk/x/auth/types"
+	vestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
 
 	"github.com/likecoin/likechain/bech32-migration/utils"
 )
@@ -12,6 +13,7 @@ import (
 func MigrateAddressBech32(ctx sdk.Context, storeKey sdk.StoreKey, cdc codec.BinaryCodec) {
 	ctx.Logger().Info("Migration of address bech32 for auth module begin")
 	migratedAccountCount := uint64(0)
+	migratedAccountTypesStat := map[string]uint64{}
 	utils.IterateStoreByPrefix(ctx, storeKey, types.AddressStoreKeyPrefix, func(bz []byte) []byte {
 		var accountI types.AccountI
 		err := cdc.UnmarshalInterface(bz, &accountI)
@@ -22,9 +24,31 @@ func MigrateAddressBech32(ctx sdk.Context, storeKey sdk.StoreKey, cdc codec.Bina
 		case *types.BaseAccount:
 			acc := accountI.(*types.BaseAccount)
 			acc.Address = utils.ConvertAccAddr(acc.Address)
+			migratedAccountTypesStat["BaseAccount"]++
 		case *types.ModuleAccount:
 			acc := accountI.(*types.ModuleAccount)
 			acc.Address = utils.ConvertAccAddr(acc.Address)
+			migratedAccountTypesStat["ModuleAccount"]++
+		case *vestingtypes.BaseVestingAccount:
+			acc := accountI.(*vestingtypes.BaseVestingAccount)
+			acc.Address = utils.ConvertAccAddr(acc.Address)
+			migratedAccountTypesStat["BaseVestingAccount"]++
+		case *vestingtypes.ContinuousVestingAccount:
+			acc := accountI.(*vestingtypes.ContinuousVestingAccount)
+			acc.Address = utils.ConvertAccAddr(acc.Address)
+			migratedAccountTypesStat["ContinuousVestingAccount"]++
+		case *vestingtypes.DelayedVestingAccount:
+			acc := accountI.(*vestingtypes.DelayedVestingAccount)
+			acc.Address = utils.ConvertAccAddr(acc.Address)
+			migratedAccountTypesStat["DelayedVestingAccount"]++
+		case *vestingtypes.PeriodicVestingAccount:
+			acc := accountI.(*vestingtypes.PeriodicVestingAccount)
+			acc.Address = utils.ConvertAccAddr(acc.Address)
+			migratedAccountTypesStat["PeriodicVestingAccount"]++
+		case *vestingtypes.PermanentLockedAccount:
+			acc := accountI.(*vestingtypes.PermanentLockedAccount)
+			acc.Address = utils.ConvertAccAddr(acc.Address)
+			migratedAccountTypesStat["PermanentLockedAccount"]++
 		default:
 			ctx.Logger().Info(
 				"Warning: unknown account type, skipping migration",
@@ -45,5 +69,6 @@ func MigrateAddressBech32(ctx sdk.Context, storeKey sdk.StoreKey, cdc codec.Bina
 	ctx.Logger().Info(
 		"Migration of address bech32 for auth module done",
 		"migrated_account_count", migratedAccountCount,
+		"migrated_account_types_stat", migratedAccountTypesStat,
 	)
 }

--- a/bech32-migration/gov/gov.go
+++ b/bech32-migration/gov/gov.go
@@ -1,0 +1,57 @@
+package gov
+
+import (
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	"github.com/cosmos/cosmos-sdk/x/gov/types"
+
+	"github.com/likecoin/likechain/bech32-migration/utils"
+)
+
+func MigrateAddressBech32(ctx sdk.Context, storeKey sdk.StoreKey, cdc codec.BinaryCodec) {
+	ctx.Logger().Info("Migration of address bech32 for gov module begin")
+	voteCount := uint64(0)
+	utils.IterateStoreByPrefix(ctx, storeKey, types.VotesKeyPrefix, func(bz []byte) []byte {
+		vote := types.Vote{}
+		cdc.MustUnmarshal(bz, &vote)
+		vote.Voter = utils.ConvertAccAddr(vote.Voter)
+		voteCount++
+		return cdc.MustMarshal(&vote)
+	})
+	depositCount := uint64(0)
+	utils.IterateStoreByPrefix(ctx, storeKey, types.DepositsKeyPrefix, func(bz []byte) []byte {
+		deposit := types.Deposit{}
+		cdc.MustUnmarshal(bz, &deposit)
+		deposit.Depositor = utils.ConvertAccAddr(deposit.Depositor)
+		depositCount++
+		return cdc.MustMarshal(&deposit)
+	})
+	communityPoolSpendProposalCount := uint64(0)
+	utils.IterateStoreByPrefix(ctx, storeKey, types.ProposalsKeyPrefix, func(bz []byte) []byte {
+		proposal := types.Proposal{}
+		cdc.MustUnmarshal(bz, &proposal)
+		content := proposal.GetContent()
+		communityPoolSpendProposal, ok := content.(*distrtypes.CommunityPoolSpendProposal)
+		if !ok {
+			return bz
+		}
+		communityPoolSpendProposal.Recipient = utils.ConvertAccAddr(communityPoolSpendProposal.Recipient)
+		newContentAny, err := codectypes.NewAnyWithValue(communityPoolSpendProposal)
+		if err != nil {
+			panic(err)
+		}
+		proposal.Content = newContentAny
+		communityPoolSpendProposalCount++
+		return cdc.MustMarshal(&proposal)
+	})
+	// TODO: community pool spend receiver address
+	ctx.Logger().Info(
+		"Migration of address bech32 for gov module done",
+		"vote_count", voteCount,
+		"deposit_count", depositCount,
+		"community_pool_spend_proposal_count", communityPoolSpendProposalCount,
+	)
+}

--- a/bech32-migration/gov/gov.go
+++ b/bech32-migration/gov/gov.go
@@ -47,7 +47,6 @@ func MigrateAddressBech32(ctx sdk.Context, storeKey sdk.StoreKey, cdc codec.Bina
 		communityPoolSpendProposalCount++
 		return cdc.MustMarshal(&proposal)
 	})
-	// TODO: community pool spend receiver address
 	ctx.Logger().Info(
 		"Migration of address bech32 for gov module done",
 		"vote_count", voteCount,

--- a/bech32-migration/slashing/slashing.go
+++ b/bech32-migration/slashing/slashing.go
@@ -1,0 +1,26 @@
+package slashing
+
+import (
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/cosmos/cosmos-sdk/x/slashing/types"
+
+	"github.com/likecoin/likechain/bech32-migration/utils"
+)
+
+func MigrateAddressBech32(ctx sdk.Context, storeKey sdk.StoreKey, cdc codec.BinaryCodec) {
+	ctx.Logger().Info("Migration of address bech32 for slashing module begin")
+	validatorSigningInfoCount := uint64(0)
+	utils.IterateStoreByPrefix(ctx, storeKey, types.ValidatorSigningInfoKeyPrefix, func(bz []byte) []byte {
+		validatorSigningInfo := types.ValidatorSigningInfo{}
+		cdc.MustUnmarshal(bz, &validatorSigningInfo)
+		validatorSigningInfo.Address = utils.ConvertConsAddr(validatorSigningInfo.Address)
+		validatorSigningInfoCount++
+		return cdc.MustMarshal(&validatorSigningInfo)
+	})
+	ctx.Logger().Info(
+		"Migration of address bech32 for slashing module done",
+		"validator_signing_info_count", validatorSigningInfoCount,
+	)
+}

--- a/bech32-migration/staking/staking.go
+++ b/bech32-migration/staking/staking.go
@@ -1,0 +1,64 @@
+package staking
+
+import (
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/cosmos/cosmos-sdk/x/staking/types"
+
+	"github.com/likecoin/likechain/bech32-migration/utils"
+)
+
+func MigrateAddressBech32(ctx sdk.Context, storeKey sdk.StoreKey, cdc codec.BinaryCodec) {
+	ctx.Logger().Info("Migration of address bech32 for staking module begin")
+	validatorCount := uint64(0)
+	utils.IterateStoreByPrefix(ctx, storeKey, types.ValidatorsKey, func(bz []byte) []byte {
+		validator := types.MustUnmarshalValidator(cdc, bz)
+		validator.OperatorAddress = utils.ConvertValAddr(validator.OperatorAddress)
+		validatorCount++
+		return types.MustMarshalValidator(cdc, &validator)
+	})
+	delegationCount := uint64(0)
+	utils.IterateStoreByPrefix(ctx, storeKey, types.DelegationKey, func(bz []byte) []byte {
+		delegation := types.MustUnmarshalDelegation(cdc, bz)
+		delegation.DelegatorAddress = utils.ConvertAccAddr(delegation.DelegatorAddress)
+		delegation.ValidatorAddress = utils.ConvertValAddr(delegation.ValidatorAddress)
+		delegationCount++
+		return types.MustMarshalDelegation(cdc, delegation)
+	})
+	redelegationCount := uint64(0)
+	utils.IterateStoreByPrefix(ctx, storeKey, types.RedelegationKey, func(bz []byte) []byte {
+		redelegation := types.MustUnmarshalRED(cdc, bz)
+		redelegation.DelegatorAddress = utils.ConvertAccAddr(redelegation.DelegatorAddress)
+		redelegation.ValidatorSrcAddress = utils.ConvertValAddr(redelegation.ValidatorSrcAddress)
+		redelegation.ValidatorDstAddress = utils.ConvertValAddr(redelegation.ValidatorDstAddress)
+		redelegationCount++
+		return types.MustMarshalRED(cdc, redelegation)
+	})
+	unbondingDelegationCount := uint64(0)
+	utils.IterateStoreByPrefix(ctx, storeKey, types.UnbondingDelegationKey, func(bz []byte) []byte {
+		unbonding := types.MustUnmarshalUBD(cdc, bz)
+		unbonding.DelegatorAddress = utils.ConvertAccAddr(unbonding.DelegatorAddress)
+		unbonding.ValidatorAddress = utils.ConvertValAddr(unbonding.ValidatorAddress)
+		unbondingDelegationCount++
+		return types.MustMarshalUBD(cdc, unbonding)
+	})
+	// Not migrating historical info, since it's weird to change "history"
+	// historicalInfoCount := uint64(0)
+	// utils.IterateStoreByPrefix(ctx, storeKey, types.HistoricalInfoKey, func(bz []byte) []byte {
+	// 	historicalInfo := types.MustUnmarshalHistoricalInfo(cdc, bz)
+	// 	for i := range historicalInfo.Valset {
+	// 		historicalInfo.Valset[i].OperatorAddress = utils.ConvertValAddr(historicalInfo.Valset[i].OperatorAddress)
+	// 	}
+	// 	historicalInfoCount++
+	// 	return cdc.MustMarshal(&historicalInfo)
+	// })
+	ctx.Logger().Info(
+		"Migration of address bech32 for staking module done",
+		"validator_count", validatorCount,
+		"delegation_count", delegationCount,
+		"redelegation_count", redelegationCount,
+		"unbonding_delegation_count", unbondingDelegationCount,
+		// "historical_info_count", historicalInfoCount,
+	)
+}

--- a/bech32-migration/staking/staking.go
+++ b/bech32-migration/staking/staking.go
@@ -43,22 +43,21 @@ func MigrateAddressBech32(ctx sdk.Context, storeKey sdk.StoreKey, cdc codec.Bina
 		unbondingDelegationCount++
 		return types.MustMarshalUBD(cdc, unbonding)
 	})
-	// Not migrating historical info, since it's weird to change "history"
-	// historicalInfoCount := uint64(0)
-	// utils.IterateStoreByPrefix(ctx, storeKey, types.HistoricalInfoKey, func(bz []byte) []byte {
-	// 	historicalInfo := types.MustUnmarshalHistoricalInfo(cdc, bz)
-	// 	for i := range historicalInfo.Valset {
-	// 		historicalInfo.Valset[i].OperatorAddress = utils.ConvertValAddr(historicalInfo.Valset[i].OperatorAddress)
-	// 	}
-	// 	historicalInfoCount++
-	// 	return cdc.MustMarshal(&historicalInfo)
-	// })
+	historicalInfoCount := uint64(0)
+	utils.IterateStoreByPrefix(ctx, storeKey, types.HistoricalInfoKey, func(bz []byte) []byte {
+		historicalInfo := types.MustUnmarshalHistoricalInfo(cdc, bz)
+		for i := range historicalInfo.Valset {
+			historicalInfo.Valset[i].OperatorAddress = utils.ConvertValAddr(historicalInfo.Valset[i].OperatorAddress)
+		}
+		historicalInfoCount++
+		return cdc.MustMarshal(&historicalInfo)
+	})
 	ctx.Logger().Info(
 		"Migration of address bech32 for staking module done",
 		"validator_count", validatorCount,
 		"delegation_count", delegationCount,
 		"redelegation_count", redelegationCount,
 		"unbonding_delegation_count", unbondingDelegationCount,
-		// "historical_info_count", historicalInfoCount,
+		"historical_info_count", historicalInfoCount,
 	)
 }

--- a/bech32-migration/utils/utils.go
+++ b/bech32-migration/utils/utils.go
@@ -1,0 +1,43 @@
+package utils
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+func ConvertValAddr(valAddr string) string {
+	parsedValAddr, err := sdk.ValAddressFromBech32(valAddr)
+	if err != nil {
+		return valAddr
+	}
+	return parsedValAddr.String()
+}
+
+func ConvertAccAddr(accAddr string) string {
+	parsedAccAddr, err := sdk.AccAddressFromBech32(accAddr)
+	if err != nil {
+		return accAddr
+	}
+	return parsedAccAddr.String()
+}
+
+func ConvertConsAddr(consAddr string) string {
+	parsedConsAddr, err := sdk.ConsAddressFromBech32(consAddr)
+	if err != nil {
+		return consAddr
+	}
+	return parsedConsAddr.String()
+}
+
+func IterateStoreByPrefix(
+	ctx sdk.Context, storeKey sdk.StoreKey, prefix []byte,
+	fn func(value []byte) (newValue []byte),
+) {
+	store := ctx.KVStore(storeKey)
+	iterator := sdk.KVStorePrefixIterator(store, prefix)
+	defer iterator.Close()
+
+	for ; iterator.Valid(); iterator.Next() {
+		newValue := fn(iterator.Value())
+		store.Set(iterator.Key(), newValue)
+	}
+}


### PR DESCRIPTION
Since some addresses are stored in string form ~~I have no idea why they do this~~, some queries will return old bech32 prefix if no migration is done.

This PR adds needed migrations by iterating related store entries, parsing and re-encoding the address, then rewriting to the store.

(Manually) tested queries:

## `auth`
- `Account`

## `bank`
- `AllBalances`
- `TotalSupply`

## `staking`
- `Validators`
- `Validator`
- `ValidatorDelegations`
- `ValidatorUnbondingDelegations`
- `Delegation`
- `UnbondingDelegation`
- `DelegatorDelegations`
- `DelegatorValidator`
- `DelegatorUnbondingDelegations`
- `HistoricalInfo`
  - We decided not to change this query, since it's kind of weird to "change history"
  - The related code are written but commented
  - Blocks after migration should be using the new bech32 prefix
  - After 10,000 blocks the records should be all using new bech32 prefix
- `Redelegations`
- `DelegatorValidators`
- `Pool`

## `gov`
- `Proposals`
  - Only the `CommunityPoolSpendProposal` are migrated, as it stores the `receiver` address as string
- `Deposits`
- `Votes`

## `slashing`
- `SigningInfos`
- `SigningInfo`

## `distribution`
- `ValidatorSlashes`
  - Weird that this is not in `slashing` module...
- `DelegationTotalRewards`

## `mint`
- `Inflation`