### PR TITLE
Update starport config to require 0 gas fee during local dev

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -14,6 +14,8 @@ build:
   main: cmd/liked
 init:
   home: "$HOME/.liked"
+  app:
+    minimum-gas-prices: 0nanolike
 genesis:
   chain_id: "likecoin-local-1"
   app_state:


### PR DESCRIPTION
Ref oursky/likecoin-chain#165

`starport chain faucet` failed after #138 due to not enough gas fee

Set starport config to use 0 gas fee during dev.

Tested problem resolved after this. 