### PR TITLE
Add test for prefix migration

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -599,6 +599,9 @@ func (app *LikeApp) GetScopedTransferKeeper() capabilitykeeper.ScopedKeeper {
 func (app *LikeApp) GetTxConfig() client.TxConfig {
 	return MakeEncodingConfig().TxConfig
 }
+func (app *LikeApp) GetKeys() map[string]*sdk.KVStoreKey {
+	return app.keys
+}
 
 // RegisterAPIRoutes registers all application module routes with the provided
 // API server.

--- a/bech32-migration/test/README.md
+++ b/bech32-migration/test/README.md
@@ -1,0 +1,30 @@
+# v2.0 migration test
+
+This script is for testing the v2.0 migration.
+
+It imports a genesis state into test app, runs the migration code, then runs test cases and export the resultant state.
+
+## Usage
+
+1. Export state from mainnet / testnet node.
+
+The file structure is: (default structure of `liked export`)
+
+```json
+{
+  "app_state": {...}
+}
+```
+
+2. Run the script:
+
+```shell
+go run ./migrate.go /path/to/input_state.json /path/to/output_state.json
+```
+
+## System requirement
+
+- 8 core cpu
+- 32GB RAM + 32GB Swap
+
+Note 64GB of memory will be used in total. Using swap file on lower end machine can avoid OOM crashes but will lengthen the processing time significantly.

--- a/bech32-migration/test/migrate.go
+++ b/bech32-migration/test/migrate.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/cosmos/cosmos-sdk/server/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/crisis"
+	"github.com/likecoin/likechain/testutil"
+
+	bech32migrationtestutil "github.com/likecoin/likechain/bech32-migration/testutil"
+
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+
+	bech32authmigration "github.com/likecoin/likechain/bech32-migration/auth"
+	bech32govmigration "github.com/likecoin/likechain/bech32-migration/gov"
+	bech32slashingmigration "github.com/likecoin/likechain/bech32-migration/slashing"
+	bech32stakingmigration "github.com/likecoin/likechain/bech32-migration/staking"
+)
+
+type MTAppOptions struct{}
+
+// Get implements AppOptions
+func (ao MTAppOptions) Get(o string) interface{} {
+	if o == crisis.FlagSkipGenesisInvariants {
+		return true
+	}
+	return nil
+}
+
+func main() {
+	// Skip this test if genesis.json is not found
+	if len(os.Args) < 3 || os.Args[1] == "" || os.Args[2] == "" {
+		panic(fmt.Errorf("Usage: `go run migrate in_genesis.json out_genesis.json`"))
+	}
+	inFilePath := os.Args[1]
+	outFilePath := os.Args[2]
+
+	if _, err := os.Stat(inFilePath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			panic(fmt.Errorf("input file does not exist: %s", err.Error()))
+		}
+		panic(fmt.Errorf("input genesis json found but failed to stat: %s", err.Error()))
+	}
+
+	if _, err := os.Stat(outFilePath); err == nil || !errors.Is(err, os.ErrNotExist) {
+		panic(fmt.Errorf("output genesis json already exists"))
+	}
+
+	jsonFile, err := os.Open(inFilePath)
+	if err != nil {
+		panic(fmt.Errorf("failed to open json file: %s", err.Error()))
+	}
+	defer jsonFile.Close()
+
+	exportedBytes, err := ioutil.ReadAll(jsonFile)
+	if err != nil {
+		panic(fmt.Errorf("failed to read json file: %s", err.Error()))
+	}
+
+	var exportedState map[string]json.RawMessage
+	if err := json.Unmarshal(exportedBytes, &exportedState); err != nil {
+		panic(fmt.Errorf("failed to unmarshal json file: %s", err.Error()))
+	}
+
+	// dealloc unused large var
+	exportedBytes = nil
+
+	// Init test app and inject genesis
+	fmt.Printf("> setup test app\n")
+	app := testutil.SetupTestAppWithState(exportedState["app_state"], MTAppOptions{})
+	ctx := app.Context
+	keys := app.GetKeys()
+	appCodec := app.AppCodec()
+
+	// dealloc unused large var
+	exportedState = nil
+
+	// Apply upgrade
+	fmt.Printf("> apply upgrade\n")
+	ctx = ctx.WithBlockGasMeter(sdk.NewInfiniteGasMeter())
+	bech32stakingmigration.MigrateAddressBech32(ctx, keys[stakingtypes.StoreKey], appCodec)
+	bech32slashingmigration.MigrateAddressBech32(ctx, keys[slashingtypes.StoreKey], appCodec)
+	bech32govmigration.MigrateAddressBech32(ctx, keys[govtypes.StoreKey], appCodec)
+	bech32authmigration.MigrateAddressBech32(ctx, keys[authtypes.StoreKey], appCodec)
+	app.Commit()
+
+	// Assert
+	fmt.Printf("> assert address prefix in stores\n")
+	if ok := bech32migrationtestutil.AssertAuthAddressBech32(ctx, keys[authtypes.StoreKey], appCodec); !ok {
+		fmt.Printf("!! Assert auth addresses failed\n")
+	}
+	if ok := bech32migrationtestutil.AssertGovAddressBech32(ctx, keys[govtypes.StoreKey], appCodec); !ok {
+		fmt.Printf("!! Assert gov addresses failed\n")
+	}
+	if ok := bech32migrationtestutil.AssertSlashingAddressBech32(ctx, keys[slashingtypes.StoreKey], appCodec); !ok {
+		fmt.Printf("!! Assert slashing addresses failed\n")
+	}
+	if ok := bech32migrationtestutil.AssertStakingAddressBech32(ctx, keys[stakingtypes.StoreKey], appCodec); !ok {
+		fmt.Printf("!! Assert staking addresses failed\n")
+	}
+
+	// Export genesis
+	fmt.Printf("> export upgraded genesis\n")
+	exportedApp, err := app.ExportAppStateAndValidators(false, []string{})
+	if err != nil {
+		panic(fmt.Errorf("failed to export app state: %s", err.Error()))
+	}
+
+	if err := os.WriteFile(outFilePath, exportedApp.AppState, 0644); err != nil {
+		panic(fmt.Errorf("failed to write result file: %s", err.Error()))
+	}
+
+	// dealloc unused large var
+	exportedApp = types.ExportedApp{}
+}

--- a/bech32-migration/testutil/auth.go
+++ b/bech32-migration/testutil/auth.go
@@ -1,0 +1,65 @@
+package testutil
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/cosmos/cosmos-sdk/x/auth/types"
+	vestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
+
+	"github.com/likecoin/likechain/bech32-migration/utils"
+)
+
+func AssertAuthAddressBech32(ctx sdk.Context, storeKey sdk.StoreKey, cdc codec.BinaryCodec) bool {
+	ok := true
+	utils.IterateStoreByPrefix(ctx, storeKey, types.AddressStoreKeyPrefix, func(bz []byte) []byte {
+		var accountI types.AccountI
+		err := cdc.UnmarshalInterface(bz, &accountI)
+		if err != nil {
+			panic(err)
+		}
+		var acc string
+		var itype string
+		switch accountI.(type) {
+		case *types.BaseAccount:
+			acc = accountI.(*types.BaseAccount).Address
+			itype = "BaseAccount"
+		case *types.ModuleAccount:
+			acc = accountI.(*types.ModuleAccount).Address
+			itype = "ModuleAccount"
+		case *vestingtypes.BaseVestingAccount:
+			acc = accountI.(*vestingtypes.BaseVestingAccount).Address
+			itype = "BaseVestingAccount"
+		case *vestingtypes.ContinuousVestingAccount:
+			acc = accountI.(*vestingtypes.ContinuousVestingAccount).Address
+			itype = "ContinuousVestingAccount"
+		case *vestingtypes.DelayedVestingAccount:
+			acc = accountI.(*vestingtypes.DelayedVestingAccount).Address
+			itype = "DelayedVestingAccount"
+		case *vestingtypes.PeriodicVestingAccount:
+			acc = accountI.(*vestingtypes.PeriodicVestingAccount).Address
+			itype = "PeriodicVestingAccount"
+		case *vestingtypes.PermanentLockedAccount:
+			acc = accountI.(*vestingtypes.PermanentLockedAccount).Address
+			itype = "PermanentLockedAccount"
+		default:
+			ctx.Logger().Info(
+				"Warning: unknown account type, skipping migration",
+				"address", accountI.GetAddress().String(),
+				"account_number", accountI.GetAccountNumber(),
+				"public_key", accountI.GetPubKey(),
+				"sequence", accountI.GetSequence(),
+			)
+			return bz
+		}
+		if !strings.HasPrefix(acc, "like") {
+			ctx.Logger().Info(fmt.Sprintf("Bad prefix found: %s, interface type: %s", acc, itype))
+			ok = false
+		}
+		return bz
+	})
+	return ok
+}

--- a/bech32-migration/testutil/gov.go
+++ b/bech32-migration/testutil/gov.go
@@ -1,0 +1,51 @@
+package testutil
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	"github.com/cosmos/cosmos-sdk/x/gov/types"
+
+	"github.com/likecoin/likechain/bech32-migration/utils"
+)
+
+func AssertGovAddressBech32(ctx sdk.Context, storeKey sdk.StoreKey, cdc codec.BinaryCodec) bool {
+	ok := true
+	utils.IterateStoreByPrefix(ctx, storeKey, types.VotesKeyPrefix, func(bz []byte) []byte {
+		vote := types.Vote{}
+		cdc.MustUnmarshal(bz, &vote)
+		if !strings.HasPrefix(vote.Voter, "like") {
+			ctx.Logger().Info(fmt.Sprintf("Bad prefix found: %s, interface type: vote.Voter", vote.Voter))
+			ok = false
+		}
+		return bz
+	})
+	utils.IterateStoreByPrefix(ctx, storeKey, types.DepositsKeyPrefix, func(bz []byte) []byte {
+		deposit := types.Deposit{}
+		cdc.MustUnmarshal(bz, &deposit)
+		if !strings.HasPrefix(deposit.Depositor, "like") {
+			ctx.Logger().Info(fmt.Sprintf("Bad prefix found: %s, interface type: deposit.Depositor", deposit.Depositor))
+			ok = false
+		}
+		return bz
+	})
+	utils.IterateStoreByPrefix(ctx, storeKey, types.ProposalsKeyPrefix, func(bz []byte) []byte {
+		proposal := types.Proposal{}
+		cdc.MustUnmarshal(bz, &proposal)
+		content := proposal.GetContent()
+		communityPoolSpendProposal, ok := content.(*distrtypes.CommunityPoolSpendProposal)
+		if !ok {
+			return bz
+		}
+		if !strings.HasPrefix(communityPoolSpendProposal.Recipient, "like") {
+			ctx.Logger().Info(fmt.Sprintf("Bad prefix found: %s, interface type: communityPoolSpendProposal.Recipient", communityPoolSpendProposal.Recipient))
+			ok = false
+		}
+		return bz
+	})
+	return ok
+}

--- a/bech32-migration/testutil/slashing.go
+++ b/bech32-migration/testutil/slashing.go
@@ -1,0 +1,27 @@
+package testutil
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/cosmos/cosmos-sdk/x/slashing/types"
+
+	"github.com/likecoin/likechain/bech32-migration/utils"
+)
+
+func AssertSlashingAddressBech32(ctx sdk.Context, storeKey sdk.StoreKey, cdc codec.BinaryCodec) bool {
+	ok := true	
+	utils.IterateStoreByPrefix(ctx, storeKey, types.ValidatorSigningInfoKeyPrefix, func(bz []byte) []byte {
+		validatorSigningInfo := types.ValidatorSigningInfo{}
+		cdc.MustUnmarshal(bz, &validatorSigningInfo)
+		if !strings.HasPrefix(validatorSigningInfo.Address, "like") {
+			ctx.Logger().Info(fmt.Sprintf("Bad prefix found: %s, interface type: validatorSigningInfo.Address", validatorSigningInfo.Address))
+			ok = false
+		}
+		return bz
+	})
+	return ok
+}

--- a/bech32-migration/testutil/staking.go
+++ b/bech32-migration/testutil/staking.go
@@ -1,0 +1,76 @@
+package testutil
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/cosmos/cosmos-sdk/x/staking/types"
+
+	"github.com/likecoin/likechain/bech32-migration/utils"
+)
+
+func AssertStakingAddressBech32(ctx sdk.Context, storeKey sdk.StoreKey, cdc codec.BinaryCodec) bool {
+	ok := true
+	utils.IterateStoreByPrefix(ctx, storeKey, types.ValidatorsKey, func(bz []byte) []byte {
+		validator := types.MustUnmarshalValidator(cdc, bz)
+		if !strings.HasPrefix(validator.OperatorAddress, "like") {
+			ctx.Logger().Info(fmt.Sprintf("Bad prefix found: %s, interface type: validator.OperatorAddress", validator.OperatorAddress))
+			ok = false
+		}
+		return bz
+	})
+	utils.IterateStoreByPrefix(ctx, storeKey, types.DelegationKey, func(bz []byte) []byte {
+		delegation := types.MustUnmarshalDelegation(cdc, bz)
+		if !strings.HasPrefix(delegation.DelegatorAddress, "like") {
+			ctx.Logger().Info(fmt.Sprintf("Bad prefix found: %s, interface type: delegation.DelegatorAddress", delegation.DelegatorAddress))
+			ok = false
+		}
+		if !strings.HasPrefix(delegation.ValidatorAddress, "like") {
+			ctx.Logger().Info(fmt.Sprintf("Bad prefix found: %s, interface type: delegation.ValidatorAddress", delegation.ValidatorAddress))
+			ok = false
+		}
+		return bz
+	})
+	utils.IterateStoreByPrefix(ctx, storeKey, types.RedelegationKey, func(bz []byte) []byte {
+		redelegation := types.MustUnmarshalRED(cdc, bz)
+		if !strings.HasPrefix(redelegation.DelegatorAddress, "like") {
+			ctx.Logger().Info(fmt.Sprintf("Bad prefix found: %s, interface type: redelegation.DelegatorAddress", redelegation.DelegatorAddress))
+			ok = false
+		}
+		if !strings.HasPrefix(redelegation.ValidatorSrcAddress, "like") {
+			ctx.Logger().Info(fmt.Sprintf("Bad prefix found: %s, interface type: redelegation.ValidatorSrcAddress", redelegation.ValidatorSrcAddress))
+			ok = false
+		}
+		if !strings.HasPrefix(redelegation.ValidatorDstAddress, "like") {
+			ctx.Logger().Info(fmt.Sprintf("Bad prefix found: %s, interface type: redelegation.ValidatorDstAddress", redelegation.ValidatorDstAddress))
+			ok = false
+		}
+		return bz
+	})
+	utils.IterateStoreByPrefix(ctx, storeKey, types.UnbondingDelegationKey, func(bz []byte) []byte {
+		unbonding := types.MustUnmarshalUBD(cdc, bz)
+		if !strings.HasPrefix(unbonding.DelegatorAddress, "like") {
+			ctx.Logger().Info(fmt.Sprintf("Bad prefix found: %s, interface type: unbonding.DelegatorAddress", unbonding.DelegatorAddress))
+			ok = false
+		}
+		if !strings.HasPrefix(unbonding.ValidatorAddress, "like") {
+			ctx.Logger().Info(fmt.Sprintf("Bad prefix found: %s, interface type: unbonding.ValidatorAddress", unbonding.ValidatorAddress))
+			ok = false
+		}
+		return types.MustMarshalUBD(cdc, unbonding)
+	})
+	utils.IterateStoreByPrefix(ctx, storeKey, types.HistoricalInfoKey, func(bz []byte) []byte {
+		historicalInfo := types.MustUnmarshalHistoricalInfo(cdc, bz)
+		for i := range historicalInfo.Valset {
+			if !strings.HasPrefix(historicalInfo.Valset[i].OperatorAddress, "like") {
+				ctx.Logger().Info(fmt.Sprintf("Bad prefix found: %s, interface type: historicalInfo.Valset[i].OperatorAddress", historicalInfo.Valset[i].OperatorAddress))
+				ok = false
+			}
+		}
+		return cdc.MustMarshal(&historicalInfo)
+	})
+	return ok
+}


### PR DESCRIPTION
Ref oursky/likecoin-chain#173

- Add test script

Ran test with mainnet state on 31 mar:
- Mainnet state: https://ourskylikecoin.blob.core.windows.net/mainnet-snapshot/genesis_latest_height_31mar.tar.gz
- Output state: https://ourskylikecoin.blob.core.windows.net/mainnet-migration-test/genesis_out_latest_height_prefix_only.tar.gz

The unit tests for prefix migrations passed. Did quick grep search in the exported state, only found `cosmos1` and `cosmosval` occurrences in proposal text content and iscn record content