### PR TITLE
Wrap `gov` module to change address bech32 prefix in `gov` CLI query results

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -397,6 +397,7 @@ func NewLikeApp(
 	// NOTE: staking module is required if HistoricalEntries param > 0
 	// NOTE: capability module's beginblocker must come before any modules using capabilities (e.g. IBC)
 	app.mm.SetOrderBeginBlockers(
+		// upgrades should be run first
 		upgradetypes.ModuleName,
 		capabilitytypes.ModuleName,
 		minttypes.ModuleName,
@@ -405,14 +406,37 @@ func NewLikeApp(
 		evidencetypes.ModuleName,
 		stakingtypes.ModuleName,
 		ibchost.ModuleName,
+		ibctransfertypes.ModuleName,
+		authtypes.ModuleName,
+		banktypes.ModuleName,
+		govtypes.ModuleName,
+		crisistypes.ModuleName,
+		genutiltypes.ModuleName,
+		authz.ModuleName,
+		feegrant.ModuleName,
+		paramstypes.ModuleName,
+		iscntypes.ModuleName,
 	)
 
 	app.mm.SetOrderEndBlockers(
 		crisistypes.ModuleName,
 		govtypes.ModuleName,
 		stakingtypes.ModuleName,
-		feegrant.ModuleName,
+		ibchost.ModuleName,
+		ibctransfertypes.ModuleName,
+		capabilitytypes.ModuleName,
+		authtypes.ModuleName,
+		banktypes.ModuleName,
+		distrtypes.ModuleName,
+		slashingtypes.ModuleName,
+		minttypes.ModuleName,
+		genutiltypes.ModuleName,
+		evidencetypes.ModuleName,
 		authz.ModuleName,
+		feegrant.ModuleName,
+		paramstypes.ModuleName,
+		upgradetypes.ModuleName,
+		iscntypes.ModuleName,
 	)
 
 	// NOTE: The genutils module must occur after staking so that pools are
@@ -433,9 +457,11 @@ func NewLikeApp(
 		ibchost.ModuleName,
 		genutiltypes.ModuleName,
 		evidencetypes.ModuleName,
+		authz.ModuleName,
 		ibctransfertypes.ModuleName,
 		feegrant.ModuleName,
-		authz.ModuleName,
+		paramstypes.ModuleName,
+		upgradetypes.ModuleName,
 		iscntypes.ModuleName,
 	)
 
@@ -450,9 +476,6 @@ func NewLikeApp(
 	app.MountMemoryStores(memKeys)
 
 	// initialize BaseApp
-	app.SetInitChainer(app.InitChainer)
-	app.SetBeginBlocker(app.BeginBlocker)
-
 	anteHandler, err := NewAnteHandler(
 		HandlerOptions{
 			HandlerOptions: ante.HandlerOptions{
@@ -470,7 +493,8 @@ func NewLikeApp(
 	}
 
 	app.SetAnteHandler(anteHandler)
-
+	app.SetInitChainer(app.InitChainer)
+	app.SetBeginBlocker(app.BeginBlocker)
 	app.SetEndBlocker(app.EndBlocker)
 
 	if loadLatest {

--- a/app/app.go
+++ b/app/app.go
@@ -623,6 +623,9 @@ func (app *LikeApp) GetScopedTransferKeeper() capabilitykeeper.ScopedKeeper {
 func (app *LikeApp) GetTxConfig() client.TxConfig {
 	return MakeEncodingConfig().TxConfig
 }
+func (app *LikeApp) GetKeys() map[string]*sdk.KVStoreKey {
+	return app.keys
+}
 
 // RegisterAPIRoutes registers all application module routes with the provided
 // API server.

--- a/app/app.go
+++ b/app/app.go
@@ -58,7 +58,6 @@ import (
 	feegrantmodule "github.com/cosmos/cosmos-sdk/x/feegrant/module"
 	"github.com/cosmos/cosmos-sdk/x/genutil"
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
-	"github.com/cosmos/cosmos-sdk/x/gov"
 	govkeeper "github.com/cosmos/cosmos-sdk/x/gov/keeper"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/cosmos/cosmos-sdk/x/mint"
@@ -91,6 +90,8 @@ import (
 	ibchost "github.com/cosmos/ibc-go/v2/modules/core/24-host"
 	ibckeeper "github.com/cosmos/ibc-go/v2/modules/core/keeper"
 
+	wrappedgov "github.com/likecoin/likechain/x/gov"
+
 	"github.com/likecoin/likechain/x/iscn"
 	iscnkeeper "github.com/likecoin/likechain/x/iscn/keeper"
 	iscntypes "github.com/likecoin/likechain/x/iscn/types"
@@ -117,7 +118,7 @@ var (
 		staking.AppModuleBasic{},
 		mint.AppModuleBasic{},
 		distr.AppModuleBasic{},
-		gov.NewAppModuleBasic(
+		wrappedgov.NewAppModuleBasic(
 			paramsclient.ProposalHandler,
 			distrclient.ProposalHandler,
 			upgradeclient.ProposalHandler,
@@ -373,7 +374,7 @@ func NewLikeApp(
 		capability.NewAppModule(appCodec, *app.CapabilityKeeper),
 		crisis.NewAppModule(&app.CrisisKeeper, skipGenesisInvariants),
 		feegrantmodule.NewAppModule(appCodec, app.AccountKeeper, app.BankKeeper, app.FeeGrantKeeper, app.interfaceRegistry),
-		gov.NewAppModule(appCodec, app.GovKeeper, app.AccountKeeper, app.BankKeeper),
+		wrappedgov.NewAppModule(appCodec, app.GovKeeper, app.AccountKeeper, app.BankKeeper),
 		mint.NewAppModule(appCodec, app.MintKeeper, app.AccountKeeper),
 		slashing.NewAppModule(
 			appCodec, app.SlashingKeeper, app.AccountKeeper, app.BankKeeper, app.StakingKeeper,

--- a/bech32-migration/auth/auth.go
+++ b/bech32-migration/auth/auth.go
@@ -5,6 +5,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/cosmos/cosmos-sdk/x/auth/types"
+	vestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
 
 	"github.com/likecoin/likechain/bech32-migration/utils"
 )
@@ -12,6 +13,7 @@ import (
 func MigrateAddressBech32(ctx sdk.Context, storeKey sdk.StoreKey, cdc codec.BinaryCodec) {
 	ctx.Logger().Info("Migration of address bech32 for auth module begin")
 	migratedAccountCount := uint64(0)
+	migratedAccountTypesStat := map[string]uint64{}
 	utils.IterateStoreByPrefix(ctx, storeKey, types.AddressStoreKeyPrefix, func(bz []byte) []byte {
 		var accountI types.AccountI
 		err := cdc.UnmarshalInterface(bz, &accountI)
@@ -22,9 +24,31 @@ func MigrateAddressBech32(ctx sdk.Context, storeKey sdk.StoreKey, cdc codec.Bina
 		case *types.BaseAccount:
 			acc := accountI.(*types.BaseAccount)
 			acc.Address = utils.ConvertAccAddr(acc.Address)
+			migratedAccountTypesStat["BaseAccount"]++
 		case *types.ModuleAccount:
 			acc := accountI.(*types.ModuleAccount)
 			acc.Address = utils.ConvertAccAddr(acc.Address)
+			migratedAccountTypesStat["ModuleAccount"]++
+		case *vestingtypes.BaseVestingAccount:
+			acc := accountI.(*vestingtypes.BaseVestingAccount)
+			acc.Address = utils.ConvertAccAddr(acc.Address)
+			migratedAccountTypesStat["BaseVestingAccount"]++
+		case *vestingtypes.ContinuousVestingAccount:
+			acc := accountI.(*vestingtypes.ContinuousVestingAccount)
+			acc.Address = utils.ConvertAccAddr(acc.Address)
+			migratedAccountTypesStat["ContinuousVestingAccount"]++
+		case *vestingtypes.DelayedVestingAccount:
+			acc := accountI.(*vestingtypes.DelayedVestingAccount)
+			acc.Address = utils.ConvertAccAddr(acc.Address)
+			migratedAccountTypesStat["DelayedVestingAccount"]++
+		case *vestingtypes.PeriodicVestingAccount:
+			acc := accountI.(*vestingtypes.PeriodicVestingAccount)
+			acc.Address = utils.ConvertAccAddr(acc.Address)
+			migratedAccountTypesStat["PeriodicVestingAccount"]++
+		case *vestingtypes.PermanentLockedAccount:
+			acc := accountI.(*vestingtypes.PermanentLockedAccount)
+			acc.Address = utils.ConvertAccAddr(acc.Address)
+			migratedAccountTypesStat["PermanentLockedAccount"]++
 		default:
 			ctx.Logger().Info(
 				"Warning: unknown account type, skipping migration",
@@ -45,5 +69,6 @@ func MigrateAddressBech32(ctx sdk.Context, storeKey sdk.StoreKey, cdc codec.Bina
 	ctx.Logger().Info(
 		"Migration of address bech32 for auth module done",
 		"migrated_account_count", migratedAccountCount,
+		"migrated_account_types_stat", migratedAccountTypesStat,
 	)
 }

--- a/bech32-migration/test/README.md
+++ b/bech32-migration/test/README.md
@@ -1,0 +1,30 @@
+# v2.0 migration test
+
+This script is for testing the v2.0 migration.
+
+It imports a genesis state into test app, runs the migration code, then runs test cases and export the resultant state.
+
+## Usage
+
+1. Export state from mainnet / testnet node.
+
+The file structure is: (default structure of `liked export`)
+
+```json
+{
+  "app_state": {...}
+}
+```
+
+2. Run the script:
+
+```shell
+go run ./migrate.go /path/to/input_state.json /path/to/output_state.json
+```
+
+## System requirement
+
+- 8 core cpu
+- 32GB RAM + 32GB Swap
+
+Note 64GB of memory will be used in total. Using swap file on lower end machine can avoid OOM crashes but will lengthen the processing time significantly.

--- a/bech32-migration/test/migrate.go
+++ b/bech32-migration/test/migrate.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/cosmos/cosmos-sdk/server/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/crisis"
+	"github.com/likecoin/likechain/testutil"
+
+	bech32migrationtestutil "github.com/likecoin/likechain/bech32-migration/testutil"
+
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+
+	bech32authmigration "github.com/likecoin/likechain/bech32-migration/auth"
+	bech32govmigration "github.com/likecoin/likechain/bech32-migration/gov"
+	bech32slashingmigration "github.com/likecoin/likechain/bech32-migration/slashing"
+	bech32stakingmigration "github.com/likecoin/likechain/bech32-migration/staking"
+)
+
+type MTAppOptions struct{}
+
+// Get implements AppOptions
+func (ao MTAppOptions) Get(o string) interface{} {
+	if o == crisis.FlagSkipGenesisInvariants {
+		return true
+	}
+	return nil
+}
+
+func main() {
+	// Skip this test if genesis.json is not found
+	if len(os.Args) < 3 || os.Args[1] == "" || os.Args[2] == "" {
+		panic(fmt.Errorf("Usage: `go run migrate in_genesis.json out_genesis.json`"))
+	}
+	inFilePath := os.Args[1]
+	outFilePath := os.Args[2]
+
+	if _, err := os.Stat(inFilePath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			panic(fmt.Errorf("input file does not exist: %s", err.Error()))
+		}
+		panic(fmt.Errorf("input genesis json found but failed to stat: %s", err.Error()))
+	}
+
+	if _, err := os.Stat(outFilePath); err == nil || !errors.Is(err, os.ErrNotExist) {
+		panic(fmt.Errorf("output genesis json already exists"))
+	}
+
+	jsonFile, err := os.Open(inFilePath)
+	if err != nil {
+		panic(fmt.Errorf("failed to open json file: %s", err.Error()))
+	}
+	defer jsonFile.Close()
+
+	exportedBytes, err := ioutil.ReadAll(jsonFile)
+	if err != nil {
+		panic(fmt.Errorf("failed to read json file: %s", err.Error()))
+	}
+
+	var exportedState map[string]json.RawMessage
+	if err := json.Unmarshal(exportedBytes, &exportedState); err != nil {
+		panic(fmt.Errorf("failed to unmarshal json file: %s", err.Error()))
+	}
+
+	// dealloc unused large var
+	exportedBytes = nil
+
+	// Init test app and inject genesis
+	fmt.Printf("> setup test app\n")
+	app := testutil.SetupTestAppWithState(exportedState["app_state"], MTAppOptions{})
+	ctx := app.Context
+	keys := app.GetKeys()
+	appCodec := app.AppCodec()
+
+	// dealloc unused large var
+	exportedState = nil
+
+	// Apply upgrade
+	fmt.Printf("> apply upgrade\n")
+	ctx = ctx.WithBlockGasMeter(sdk.NewInfiniteGasMeter())
+	bech32stakingmigration.MigrateAddressBech32(ctx, keys[stakingtypes.StoreKey], appCodec)
+	bech32slashingmigration.MigrateAddressBech32(ctx, keys[slashingtypes.StoreKey], appCodec)
+	bech32govmigration.MigrateAddressBech32(ctx, keys[govtypes.StoreKey], appCodec)
+	bech32authmigration.MigrateAddressBech32(ctx, keys[authtypes.StoreKey], appCodec)
+	app.Commit()
+
+	// Assert
+	fmt.Printf("> assert address prefix in stores\n")
+	if ok := bech32migrationtestutil.AssertAuthAddressBech32(ctx, keys[authtypes.StoreKey], appCodec); !ok {
+		fmt.Printf("!! Assert auth addresses failed\n")
+	}
+	if ok := bech32migrationtestutil.AssertGovAddressBech32(ctx, keys[govtypes.StoreKey], appCodec); !ok {
+		fmt.Printf("!! Assert gov addresses failed\n")
+	}
+	if ok := bech32migrationtestutil.AssertSlashingAddressBech32(ctx, keys[slashingtypes.StoreKey], appCodec); !ok {
+		fmt.Printf("!! Assert slashing addresses failed\n")
+	}
+	if ok := bech32migrationtestutil.AssertStakingAddressBech32(ctx, keys[stakingtypes.StoreKey], appCodec); !ok {
+		fmt.Printf("!! Assert staking addresses failed\n")
+	}
+
+	// Export genesis
+	fmt.Printf("> export upgraded genesis\n")
+	exportedApp, err := app.ExportAppStateAndValidators(false, []string{})
+	if err != nil {
+		panic(fmt.Errorf("failed to export app state: %s", err.Error()))
+	}
+
+	if err := os.WriteFile(outFilePath, exportedApp.AppState, 0644); err != nil {
+		panic(fmt.Errorf("failed to write result file: %s", err.Error()))
+	}
+
+	// dealloc unused large var
+	exportedApp = types.ExportedApp{}
+}

--- a/bech32-migration/testutil/auth.go
+++ b/bech32-migration/testutil/auth.go
@@ -1,0 +1,65 @@
+package testutil
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/cosmos/cosmos-sdk/x/auth/types"
+	vestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
+
+	"github.com/likecoin/likechain/bech32-migration/utils"
+)
+
+func AssertAuthAddressBech32(ctx sdk.Context, storeKey sdk.StoreKey, cdc codec.BinaryCodec) bool {
+	ok := true
+	utils.IterateStoreByPrefix(ctx, storeKey, types.AddressStoreKeyPrefix, func(bz []byte) []byte {
+		var accountI types.AccountI
+		err := cdc.UnmarshalInterface(bz, &accountI)
+		if err != nil {
+			panic(err)
+		}
+		var acc string
+		var itype string
+		switch accountI.(type) {
+		case *types.BaseAccount:
+			acc = accountI.(*types.BaseAccount).Address
+			itype = "BaseAccount"
+		case *types.ModuleAccount:
+			acc = accountI.(*types.ModuleAccount).Address
+			itype = "ModuleAccount"
+		case *vestingtypes.BaseVestingAccount:
+			acc = accountI.(*vestingtypes.BaseVestingAccount).Address
+			itype = "BaseVestingAccount"
+		case *vestingtypes.ContinuousVestingAccount:
+			acc = accountI.(*vestingtypes.ContinuousVestingAccount).Address
+			itype = "ContinuousVestingAccount"
+		case *vestingtypes.DelayedVestingAccount:
+			acc = accountI.(*vestingtypes.DelayedVestingAccount).Address
+			itype = "DelayedVestingAccount"
+		case *vestingtypes.PeriodicVestingAccount:
+			acc = accountI.(*vestingtypes.PeriodicVestingAccount).Address
+			itype = "PeriodicVestingAccount"
+		case *vestingtypes.PermanentLockedAccount:
+			acc = accountI.(*vestingtypes.PermanentLockedAccount).Address
+			itype = "PermanentLockedAccount"
+		default:
+			ctx.Logger().Info(
+				"Warning: unknown account type, skipping migration",
+				"address", accountI.GetAddress().String(),
+				"account_number", accountI.GetAccountNumber(),
+				"public_key", accountI.GetPubKey(),
+				"sequence", accountI.GetSequence(),
+			)
+			return bz
+		}
+		if !strings.HasPrefix(acc, "like") {
+			ctx.Logger().Info(fmt.Sprintf("Bad prefix found: %s, interface type: %s", acc, itype))
+			ok = false
+		}
+		return bz
+	})
+	return ok
+}

--- a/bech32-migration/testutil/gov.go
+++ b/bech32-migration/testutil/gov.go
@@ -1,0 +1,51 @@
+package testutil
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	"github.com/cosmos/cosmos-sdk/x/gov/types"
+
+	"github.com/likecoin/likechain/bech32-migration/utils"
+)
+
+func AssertGovAddressBech32(ctx sdk.Context, storeKey sdk.StoreKey, cdc codec.BinaryCodec) bool {
+	ok := true
+	utils.IterateStoreByPrefix(ctx, storeKey, types.VotesKeyPrefix, func(bz []byte) []byte {
+		vote := types.Vote{}
+		cdc.MustUnmarshal(bz, &vote)
+		if !strings.HasPrefix(vote.Voter, "like") {
+			ctx.Logger().Info(fmt.Sprintf("Bad prefix found: %s, interface type: vote.Voter", vote.Voter))
+			ok = false
+		}
+		return bz
+	})
+	utils.IterateStoreByPrefix(ctx, storeKey, types.DepositsKeyPrefix, func(bz []byte) []byte {
+		deposit := types.Deposit{}
+		cdc.MustUnmarshal(bz, &deposit)
+		if !strings.HasPrefix(deposit.Depositor, "like") {
+			ctx.Logger().Info(fmt.Sprintf("Bad prefix found: %s, interface type: deposit.Depositor", deposit.Depositor))
+			ok = false
+		}
+		return bz
+	})
+	utils.IterateStoreByPrefix(ctx, storeKey, types.ProposalsKeyPrefix, func(bz []byte) []byte {
+		proposal := types.Proposal{}
+		cdc.MustUnmarshal(bz, &proposal)
+		content := proposal.GetContent()
+		communityPoolSpendProposal, ok := content.(*distrtypes.CommunityPoolSpendProposal)
+		if !ok {
+			return bz
+		}
+		if !strings.HasPrefix(communityPoolSpendProposal.Recipient, "like") {
+			ctx.Logger().Info(fmt.Sprintf("Bad prefix found: %s, interface type: communityPoolSpendProposal.Recipient", communityPoolSpendProposal.Recipient))
+			ok = false
+		}
+		return bz
+	})
+	return ok
+}

--- a/bech32-migration/testutil/slashing.go
+++ b/bech32-migration/testutil/slashing.go
@@ -1,0 +1,27 @@
+package testutil
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/cosmos/cosmos-sdk/x/slashing/types"
+
+	"github.com/likecoin/likechain/bech32-migration/utils"
+)
+
+func AssertSlashingAddressBech32(ctx sdk.Context, storeKey sdk.StoreKey, cdc codec.BinaryCodec) bool {
+	ok := true	
+	utils.IterateStoreByPrefix(ctx, storeKey, types.ValidatorSigningInfoKeyPrefix, func(bz []byte) []byte {
+		validatorSigningInfo := types.ValidatorSigningInfo{}
+		cdc.MustUnmarshal(bz, &validatorSigningInfo)
+		if !strings.HasPrefix(validatorSigningInfo.Address, "like") {
+			ctx.Logger().Info(fmt.Sprintf("Bad prefix found: %s, interface type: validatorSigningInfo.Address", validatorSigningInfo.Address))
+			ok = false
+		}
+		return bz
+	})
+	return ok
+}

--- a/bech32-migration/testutil/staking.go
+++ b/bech32-migration/testutil/staking.go
@@ -1,0 +1,76 @@
+package testutil
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/cosmos/cosmos-sdk/x/staking/types"
+
+	"github.com/likecoin/likechain/bech32-migration/utils"
+)
+
+func AssertStakingAddressBech32(ctx sdk.Context, storeKey sdk.StoreKey, cdc codec.BinaryCodec) bool {
+	ok := true
+	utils.IterateStoreByPrefix(ctx, storeKey, types.ValidatorsKey, func(bz []byte) []byte {
+		validator := types.MustUnmarshalValidator(cdc, bz)
+		if !strings.HasPrefix(validator.OperatorAddress, "like") {
+			ctx.Logger().Info(fmt.Sprintf("Bad prefix found: %s, interface type: validator.OperatorAddress", validator.OperatorAddress))
+			ok = false
+		}
+		return bz
+	})
+	utils.IterateStoreByPrefix(ctx, storeKey, types.DelegationKey, func(bz []byte) []byte {
+		delegation := types.MustUnmarshalDelegation(cdc, bz)
+		if !strings.HasPrefix(delegation.DelegatorAddress, "like") {
+			ctx.Logger().Info(fmt.Sprintf("Bad prefix found: %s, interface type: delegation.DelegatorAddress", delegation.DelegatorAddress))
+			ok = false
+		}
+		if !strings.HasPrefix(delegation.ValidatorAddress, "like") {
+			ctx.Logger().Info(fmt.Sprintf("Bad prefix found: %s, interface type: delegation.ValidatorAddress", delegation.ValidatorAddress))
+			ok = false
+		}
+		return bz
+	})
+	utils.IterateStoreByPrefix(ctx, storeKey, types.RedelegationKey, func(bz []byte) []byte {
+		redelegation := types.MustUnmarshalRED(cdc, bz)
+		if !strings.HasPrefix(redelegation.DelegatorAddress, "like") {
+			ctx.Logger().Info(fmt.Sprintf("Bad prefix found: %s, interface type: redelegation.DelegatorAddress", redelegation.DelegatorAddress))
+			ok = false
+		}
+		if !strings.HasPrefix(redelegation.ValidatorSrcAddress, "like") {
+			ctx.Logger().Info(fmt.Sprintf("Bad prefix found: %s, interface type: redelegation.ValidatorSrcAddress", redelegation.ValidatorSrcAddress))
+			ok = false
+		}
+		if !strings.HasPrefix(redelegation.ValidatorDstAddress, "like") {
+			ctx.Logger().Info(fmt.Sprintf("Bad prefix found: %s, interface type: redelegation.ValidatorDstAddress", redelegation.ValidatorDstAddress))
+			ok = false
+		}
+		return bz
+	})
+	utils.IterateStoreByPrefix(ctx, storeKey, types.UnbondingDelegationKey, func(bz []byte) []byte {
+		unbonding := types.MustUnmarshalUBD(cdc, bz)
+		if !strings.HasPrefix(unbonding.DelegatorAddress, "like") {
+			ctx.Logger().Info(fmt.Sprintf("Bad prefix found: %s, interface type: unbonding.DelegatorAddress", unbonding.DelegatorAddress))
+			ok = false
+		}
+		if !strings.HasPrefix(unbonding.ValidatorAddress, "like") {
+			ctx.Logger().Info(fmt.Sprintf("Bad prefix found: %s, interface type: unbonding.ValidatorAddress", unbonding.ValidatorAddress))
+			ok = false
+		}
+		return types.MustMarshalUBD(cdc, unbonding)
+	})
+	utils.IterateStoreByPrefix(ctx, storeKey, types.HistoricalInfoKey, func(bz []byte) []byte {
+		historicalInfo := types.MustUnmarshalHistoricalInfo(cdc, bz)
+		for i := range historicalInfo.Valset {
+			if !strings.HasPrefix(historicalInfo.Valset[i].OperatorAddress, "like") {
+				ctx.Logger().Info(fmt.Sprintf("Bad prefix found: %s, interface type: historicalInfo.Valset[i].OperatorAddress", historicalInfo.Valset[i].OperatorAddress))
+				ok = false
+			}
+		}
+		return cdc.MustMarshal(&historicalInfo)
+	})
+	return ok
+}

--- a/x/gov/cli/query.go
+++ b/x/gov/cli/query.go
@@ -1,0 +1,319 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	gcutils "github.com/cosmos/cosmos-sdk/x/gov/client/utils"
+	"github.com/cosmos/cosmos-sdk/x/gov/types"
+
+	originalcli "github.com/cosmos/cosmos-sdk/x/gov/client/cli"
+
+	bech32utils "github.com/likecoin/likechain/bech32-migration/utils"
+)
+
+// This is to override the query commands which query results by Tx query, so that the returned addresses could be
+// further processed before displaying
+
+func convertAddr(s string) (string, error) {
+	addr, err := sdk.AccAddressFromBech32(s)
+	if err != nil {
+		return "", err
+	}
+	return addr.String(), nil
+}
+
+func GetQueryCmd() *cobra.Command {
+	govQueryCmd := originalcli.GetQueryCmd()
+	govQueryCmd.RemoveCommand(govQueryCmd.Commands()...)
+	govQueryCmd.AddCommand(
+		originalcli.GetCmdQueryProposal(),
+		originalcli.GetCmdQueryProposals(),
+		GetCmdQueryVote(),
+		GetCmdQueryVotes(),
+		originalcli.GetCmdQueryParam(),
+		originalcli.GetCmdQueryParams(),
+		GetCmdQueryProposer(),
+		GetCmdQueryDeposit(),
+		GetCmdQueryDeposits(),
+		originalcli.GetCmdQueryTally(),
+	)
+	return govQueryCmd
+}
+
+func GetCmdQueryVote() *cobra.Command {
+	cmd := originalcli.GetCmdQueryVote()
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		clientCtx, err := client.GetClientQueryContext(cmd)
+		if err != nil {
+			return err
+		}
+		queryClient := types.NewQueryClient(clientCtx)
+
+		// validate that the proposal id is a uint
+		proposalID, err := strconv.ParseUint(args[0], 10, 64)
+		if err != nil {
+			return fmt.Errorf("proposal-id %s not a valid int, please input a valid proposal-id", args[0])
+		}
+
+		// check to see if the proposal is in the store
+		ctx := cmd.Context()
+		_, err = queryClient.Proposal(
+			ctx,
+			&types.QueryProposalRequest{ProposalId: proposalID},
+		)
+		if err != nil {
+			return fmt.Errorf("failed to fetch proposal-id %d: %s", proposalID, err)
+		}
+
+		voterAddr, err := sdk.AccAddressFromBech32(args[1])
+		if err != nil {
+			return err
+		}
+
+		res, err := queryClient.Vote(
+			ctx,
+			&types.QueryVoteRequest{ProposalId: proposalID, Voter: args[1]},
+		)
+		if err != nil {
+			return err
+		}
+
+		vote := res.GetVote()
+		if vote.Empty() {
+			params := types.NewQueryVoteParams(proposalID, voterAddr)
+			resByTxQuery, err := gcutils.QueryVoteByTxQuery(clientCtx, params)
+
+			if err != nil {
+				return err
+			}
+
+			if err := clientCtx.Codec.UnmarshalJSON(resByTxQuery, &vote); err != nil {
+				return err
+			}
+			vote.Voter = bech32utils.ConvertAccAddr(vote.Voter)
+		}
+
+		return clientCtx.PrintProto(&res.Vote)
+	}
+	return cmd
+}
+
+func GetCmdQueryVotes() *cobra.Command {
+	cmd := originalcli.GetCmdQueryVotes()
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		clientCtx, err := client.GetClientQueryContext(cmd)
+		if err != nil {
+			return err
+		}
+		queryClient := types.NewQueryClient(clientCtx)
+
+		// validate that the proposal id is a uint
+		proposalID, err := strconv.ParseUint(args[0], 10, 64)
+		if err != nil {
+			return fmt.Errorf("proposal-id %s not a valid int, please input a valid proposal-id", args[0])
+		}
+
+		// check to see if the proposal is in the store
+		ctx := cmd.Context()
+		proposalRes, err := queryClient.Proposal(
+			ctx,
+			&types.QueryProposalRequest{ProposalId: proposalID},
+		)
+		if err != nil {
+			return fmt.Errorf("failed to fetch proposal-id %d: %s", proposalID, err)
+		}
+
+		propStatus := proposalRes.GetProposal().Status
+		if !(propStatus == types.StatusVotingPeriod || propStatus == types.StatusDepositPeriod) {
+			page, _ := cmd.Flags().GetInt(flags.FlagPage)
+			limit, _ := cmd.Flags().GetInt(flags.FlagLimit)
+
+			params := types.NewQueryProposalVotesParams(proposalID, page, limit)
+			resByTxQuery, err := gcutils.QueryVotesByTxQuery(clientCtx, params)
+			if err != nil {
+				return err
+			}
+
+			var votes types.Votes
+			// TODO migrate to use JSONCodec (implement MarshalJSONArray
+			// or wrap lists of proto.Message in some other message)
+			clientCtx.LegacyAmino.MustUnmarshalJSON(resByTxQuery, &votes)
+			for i := range votes {
+				votes[i].Voter = bech32utils.ConvertAccAddr(votes[i].Voter)
+			}
+			return clientCtx.PrintObjectLegacy(votes)
+
+		}
+
+		pageReq, err := client.ReadPageRequest(cmd.Flags())
+		if err != nil {
+			return err
+		}
+
+		res, err := queryClient.Votes(
+			ctx,
+			&types.QueryVotesRequest{ProposalId: proposalID, Pagination: pageReq},
+		)
+
+		if err != nil {
+			return err
+		}
+
+		return clientCtx.PrintProto(res)
+
+	}
+
+	return cmd
+}
+
+func GetCmdQueryDeposit() *cobra.Command {
+	cmd := originalcli.GetCmdQueryDeposit()
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		clientCtx, err := client.GetClientQueryContext(cmd)
+		if err != nil {
+			return err
+		}
+		queryClient := types.NewQueryClient(clientCtx)
+
+		// validate that the proposal id is a uint
+		proposalID, err := strconv.ParseUint(args[0], 10, 64)
+		if err != nil {
+			return fmt.Errorf("proposal-id %s not a valid uint, please input a valid proposal-id", args[0])
+		}
+
+		// check to see if the proposal is in the store
+		ctx := cmd.Context()
+		proposalRes, err := queryClient.Proposal(
+			ctx,
+			&types.QueryProposalRequest{ProposalId: proposalID},
+		)
+		if err != nil {
+			return fmt.Errorf("failed to fetch proposal-id %d: %s", proposalID, err)
+		}
+
+		depositorAddr, err := sdk.AccAddressFromBech32(args[1])
+		if err != nil {
+			return err
+		}
+
+		var deposit types.Deposit
+		propStatus := proposalRes.Proposal.Status
+		if !(propStatus == types.StatusVotingPeriod || propStatus == types.StatusDepositPeriod) {
+			params := types.NewQueryDepositParams(proposalID, depositorAddr)
+			resByTxQuery, err := gcutils.QueryDepositByTxQuery(clientCtx, params)
+			if err != nil {
+				return err
+			}
+			clientCtx.Codec.MustUnmarshalJSON(resByTxQuery, &deposit)
+			deposit.Depositor = bech32utils.ConvertAccAddr(deposit.Depositor)
+			return clientCtx.PrintProto(&deposit)
+		}
+
+		res, err := queryClient.Deposit(
+			ctx,
+			&types.QueryDepositRequest{ProposalId: proposalID, Depositor: args[1]},
+		)
+		if err != nil {
+			return err
+		}
+
+		return clientCtx.PrintProto(&res.Deposit)
+	}
+	return cmd
+}
+
+func GetCmdQueryDeposits() *cobra.Command {
+	cmd := originalcli.GetCmdQueryDeposits()
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		clientCtx, err := client.GetClientQueryContext(cmd)
+		if err != nil {
+			return err
+		}
+		queryClient := types.NewQueryClient(clientCtx)
+
+		// validate that the proposal id is a uint
+		proposalID, err := strconv.ParseUint(args[0], 10, 64)
+		if err != nil {
+			return fmt.Errorf("proposal-id %s not a valid uint, please input a valid proposal-id", args[0])
+		}
+
+		// check to see if the proposal is in the store
+		ctx := cmd.Context()
+		proposalRes, err := queryClient.Proposal(
+			ctx,
+			&types.QueryProposalRequest{ProposalId: proposalID},
+		)
+		if err != nil {
+			return fmt.Errorf("failed to fetch proposal-id %d: %s", proposalID, err)
+		}
+
+		propStatus := proposalRes.GetProposal().Status
+		if !(propStatus == types.StatusVotingPeriod || propStatus == types.StatusDepositPeriod) {
+			params := types.NewQueryProposalParams(proposalID)
+			resByTxQuery, err := gcutils.QueryDepositsByTxQuery(clientCtx, params)
+			if err != nil {
+				return err
+			}
+
+			var dep types.Deposits
+			// TODO migrate to use JSONCodec (implement MarshalJSONArray
+			// or wrap lists of proto.Message in some other message)
+			clientCtx.LegacyAmino.MustUnmarshalJSON(resByTxQuery, &dep)
+
+			for i := range dep {
+				dep[i].Depositor = bech32utils.ConvertAccAddr(dep[i].Depositor)
+			}
+
+			return clientCtx.PrintObjectLegacy(dep)
+		}
+
+		pageReq, err := client.ReadPageRequest(cmd.Flags())
+		if err != nil {
+			return err
+		}
+
+		res, err := queryClient.Deposits(
+			ctx,
+			&types.QueryDepositsRequest{ProposalId: proposalID, Pagination: pageReq},
+		)
+
+		if err != nil {
+			return err
+		}
+
+		return clientCtx.PrintProto(res)
+	}
+	return cmd
+}
+
+func GetCmdQueryProposer() *cobra.Command {
+	cmd := originalcli.GetCmdQueryProposer()
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		clientCtx, err := client.GetClientQueryContext(cmd)
+		if err != nil {
+			return err
+		}
+
+		// validate that the proposalID is a uint
+		proposalID, err := strconv.ParseUint(args[0], 10, 64)
+		if err != nil {
+			return fmt.Errorf("proposal-id %s is not a valid uint", args[0])
+		}
+
+		prop, err := gcutils.QueryProposerByTxQuery(clientCtx, proposalID)
+		if err != nil {
+			return err
+		}
+
+		prop.Proposer = bech32utils.ConvertAccAddr(prop.Proposer)
+
+		return clientCtx.PrintObjectLegacy(prop)
+	}
+	return cmd
+}

--- a/x/gov/module.go
+++ b/x/gov/module.go
@@ -1,0 +1,57 @@
+package gov
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	originalgov "github.com/cosmos/cosmos-sdk/x/gov"
+	govclient "github.com/cosmos/cosmos-sdk/x/gov/client"
+	"github.com/cosmos/cosmos-sdk/x/gov/keeper"
+	"github.com/cosmos/cosmos-sdk/x/gov/types"
+
+	"github.com/likecoin/likechain/x/gov/cli"
+)
+
+type AppModuleBasic struct {
+	originalgov.AppModuleBasic
+}
+
+var (
+	_ module.AppModule           = AppModule{}
+	_ module.AppModuleBasic      = AppModuleBasic{}
+	_ module.AppModuleSimulation = AppModule{}
+)
+
+func NewAppModuleBasic(proposalHandlers ...govclient.ProposalHandler) AppModuleBasic {
+	return AppModuleBasic{
+		AppModuleBasic: originalgov.NewAppModuleBasic(proposalHandlers...),
+	}
+}
+
+func (AppModuleBasic) GetQueryCmd() *cobra.Command {
+	return cli.GetQueryCmd()
+}
+
+// TODO: RegisterRESTRoutes
+
+// Go only allows "inheritence" from one embedded type
+// If both types (in our case originalgov.AppModule and our AppModuleBasic) implements module.AppModuleBasic, then no
+// methods will be "inherited" as Go requires developer to explicitly select one implementation (by implementing them).
+// Therefore here we simply override one method instead of embedding AppModuleBasic (which actually doesn't reuse the
+// code)
+type AppModule struct {
+	originalgov.AppModule
+}
+
+func (AppModule) GetQueryCmd() *cobra.Command {
+	return cli.GetQueryCmd()
+}
+
+// TODO: RegisterRESTRoutes
+
+func NewAppModule(cdc codec.Codec, keeper keeper.Keeper, ak types.AccountKeeper, bk types.BankKeeper) AppModule {
+	return AppModule{
+		AppModule: originalgov.NewAppModule(cdc, keeper, ak, bk),
+	}
+}


### PR DESCRIPTION
Resolves oursky/likecoin-chain#182 

Wrapping the `gov` module doesn't need to fork SDK (or maintain another piece of code in the already forked SDK), but need to copy the code in the related commands, so not sure if it is a better way

Not sure if we should do REST queries, so marked as TODO in the code.