### PR TITLE
Add formatter for proto files

### DIFF
--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -18,5 +18,7 @@ jobs:
         run: make gen-proto
       - name: update proto dependency
         run: make proto-update-deps
+      - name: format-check
+        run: make proto-format-check
       - name: lint
         run: make proto-lint

--- a/Makefile
+++ b/Makefile
@@ -139,8 +139,10 @@ gen-proto: x/
 	./scripts/gen_proto.sh
 
 proto-format:
-	@echo "Formatting Protobuf files"
-	find ./ -not -path "./third_party/*" -name *.proto -exec clang-format -i {} \;
+	@$(DOCKER_BUF) format -w
+
+proto-format-check:
+	@$(DOCKER_BUF) format --diff --exit-code
 
 proto-lint:
 	@$(DOCKER_BUF) lint --error-format=json

--- a/proto/likechain/iscn/genesis.proto
+++ b/proto/likechain/iscn/genesis.proto
@@ -1,4 +1,5 @@
 syntax = "proto3";
+
 package likechain.iscn;
 
 import "gogoproto/gogo.proto";
@@ -13,9 +14,7 @@ message GenesisState {
     uint64 latest_version = 3;
   }
   Params params = 1 [(gogoproto.nullable) = false];
-  repeated ContentIdRecord content_id_records = 2 [
-    (gogoproto.nullable) = false
-  ];
+  repeated ContentIdRecord content_id_records = 2 [(gogoproto.nullable) = false];
   repeated bytes iscn_records = 3 [
     (gogoproto.nullable) = false,
     (gogoproto.customtype) = "IscnInput"

--- a/proto/likechain/iscn/iscnid.proto
+++ b/proto/likechain/iscn/iscnid.proto
@@ -1,4 +1,5 @@
 syntax = "proto3";
+
 package likechain.iscn;
 
 import "gogoproto/gogo.proto";
@@ -6,21 +7,19 @@ import "gogoproto/gogo.proto";
 option go_package = "github.com/likecoin/likechain/x/iscn/types";
 
 message IscnIdPrefix {
-  option (gogoproto.equal)            = true;
+  option (gogoproto.equal) = true;
   option (gogoproto.goproto_stringer) = false;
-  option (gogoproto.stringer)         = false;
+  option (gogoproto.stringer) = false;
 
   string registry_name = 1;
   string content_id = 2;
 }
 
 message IscnId {
-  option (gogoproto.equal)            = true;
+  option (gogoproto.equal) = true;
   option (gogoproto.goproto_stringer) = false;
-  option (gogoproto.stringer)         = false;
+  option (gogoproto.stringer) = false;
 
-  IscnIdPrefix prefix = 1 [
-    (gogoproto.nullable) = false
-  ];
+  IscnIdPrefix prefix = 1 [(gogoproto.nullable) = false];
   uint64 version = 2;
 }

--- a/proto/likechain/iscn/params.proto
+++ b/proto/likechain/iscn/params.proto
@@ -1,19 +1,18 @@
 syntax = "proto3";
+
 package likechain.iscn;
 
-import "gogoproto/gogo.proto";
 import "cosmos/base/v1beta1/coin.proto";
+import "gogoproto/gogo.proto";
 
 option go_package = "github.com/likecoin/likechain/x/iscn/types";
 
 message Params {
-  option (gogoproto.equal)            = false;
+  option (gogoproto.equal) = false;
   option (gogoproto.goproto_stringer) = false;
-  option (gogoproto.stringer)         = false;
-  option (gogoproto.goproto_getters)  = false;
+  option (gogoproto.stringer) = false;
+  option (gogoproto.goproto_getters) = false;
 
   string registry_name = 1;
-  cosmos.base.v1beta1.DecCoin fee_per_byte = 2 [
-    (gogoproto.nullable) = false
-  ];
+  cosmos.base.v1beta1.DecCoin fee_per_byte = 2 [(gogoproto.nullable) = false];
 }

--- a/proto/likechain/iscn/query.proto
+++ b/proto/likechain/iscn/query.proto
@@ -1,4 +1,5 @@
 syntax = "proto3";
+
 package likechain.iscn;
 
 import "gogoproto/gogo.proto";
@@ -68,7 +69,7 @@ message QueryRecordsByIdRequest {
   uint64 to_version = 3;
 }
 
-message QueryRecordsByIdResponse  {
+message QueryRecordsByIdResponse {
   string owner = 1;
   uint64 latest_version = 2;
   repeated QueryResponseRecord records = 3 [(gogoproto.nullable) = false];
@@ -85,7 +86,7 @@ message QueryRecordsByFingerprintRequest {
   uint64 from_sequence = 2;
 }
 
-message QueryRecordsByFingerprintResponse  {
+message QueryRecordsByFingerprintResponse {
   repeated QueryResponseRecord records = 1 [(gogoproto.nullable) = false];
 
   // For pagination.
@@ -102,13 +103,12 @@ message QueryRecordsByOwnerRequest {
   uint64 from_sequence = 2;
 }
 
-message QueryRecordsByOwnerResponse  {
+message QueryRecordsByOwnerResponse {
   repeated QueryResponseRecord records = 1 [(gogoproto.nullable) = false];
   uint64 next_sequence = 2;
 }
 
-message QueryParamsRequest {
-}
+message QueryParamsRequest {}
 
 message QueryParamsResponse {
   Params params = 1 [(gogoproto.nullable) = false];

--- a/proto/likechain/iscn/store.proto
+++ b/proto/likechain/iscn/store.proto
@@ -1,4 +1,5 @@
 syntax = "proto3";
+
 package likechain.iscn;
 
 import "gogoproto/gogo.proto";
@@ -7,9 +8,7 @@ import "likechain/iscn/iscnid.proto";
 option go_package = "github.com/likecoin/likechain/x/iscn/types";
 
 message StoreRecord {
-  IscnId iscn_id = 1 [
-    (gogoproto.nullable) = false
-  ];
+  IscnId iscn_id = 1 [(gogoproto.nullable) = false];
   bytes cid_bytes = 2;
   bytes data = 3 [
     (gogoproto.nullable) = false,

--- a/proto/likechain/iscn/tx.proto
+++ b/proto/likechain/iscn/tx.proto
@@ -1,4 +1,5 @@
 syntax = "proto3";
+
 package likechain.iscn;
 
 import "gogoproto/gogo.proto";
@@ -21,9 +22,7 @@ message IscnRecord {
   repeated string contentFingerprints = 2;
 
   // Here, `IscnInput` is JSON encoded bytes
-  repeated bytes stakeholders = 3 [
-    (gogoproto.customtype) = "IscnInput"
-  ];
+  repeated bytes stakeholders = 3 [(gogoproto.customtype) = "IscnInput"];
   bytes contentMetadata = 4 [
     (gogoproto.nullable) = false,
     (gogoproto.customtype) = "IscnInput"
@@ -32,9 +31,7 @@ message IscnRecord {
 
 message MsgCreateIscnRecord {
   string from = 1;
-  IscnRecord record = 2 [
-    (gogoproto.nullable) = false
-  ];
+  IscnRecord record = 2 [(gogoproto.nullable) = false];
 }
 
 message MsgCreateIscnRecordResponse {
@@ -45,9 +42,7 @@ message MsgCreateIscnRecordResponse {
 message MsgUpdateIscnRecord {
   string from = 1;
   string iscn_id = 2;
-  IscnRecord record = 3 [
-    (gogoproto.nullable) = false
-  ];
+  IscnRecord record = 3 [(gogoproto.nullable) = false];
 }
 
 message MsgUpdateIscnRecordResponse {
@@ -61,5 +56,4 @@ message MsgChangeIscnRecordOwnership {
   string new_owner = 3;
 }
 
-message MsgChangeIscnRecordOwnershipResponse {
-}
+message MsgChangeIscnRecordOwnershipResponse {}

--- a/proto/likechain/likenft/class_data.proto
+++ b/proto/likechain/likenft/class_data.proto
@@ -1,4 +1,5 @@
 syntax = "proto3";
+
 package likechain.likenft;
 
 import "gogoproto/gogo.proto";
@@ -31,8 +32,11 @@ message ClassParent {
 }
 
 message MintPeriod {
-  google.protobuf.Timestamp start_time = 1 [(gogoproto.stdtime) = true, (gogoproto.nullable) = false];
-  repeated string allowed_addresses = 2 ;
+  google.protobuf.Timestamp start_time = 1 [
+    (gogoproto.stdtime) = true,
+    (gogoproto.nullable) = false
+  ];
+  repeated string allowed_addresses = 2;
   uint64 mint_price = 3;
 }
 
@@ -44,5 +48,8 @@ message ClassConfig {
 
 message BlindBoxConfig {
   repeated MintPeriod mint_periods = 1 [(gogoproto.nullable) = false];
-  google.protobuf.Timestamp reveal_time = 2 [(gogoproto.stdtime) = true, (gogoproto.nullable) = false];
+  google.protobuf.Timestamp reveal_time = 2 [
+    (gogoproto.stdtime) = true,
+    (gogoproto.nullable) = false
+  ];
 }

--- a/proto/likechain/likenft/class_input.proto
+++ b/proto/likechain/likenft/class_input.proto
@@ -1,4 +1,5 @@
 syntax = "proto3";
+
 package likechain.likenft;
 
 import "gogoproto/gogo.proto";

--- a/proto/likechain/likenft/class_reveal_queue.proto
+++ b/proto/likechain/likenft/class_reveal_queue.proto
@@ -1,13 +1,16 @@
 syntax = "proto3";
-package likechain.likenft;
 
-option go_package = "github.com/likecoin/likechain/x/likenft/types";
+package likechain.likenft;
 
 import "gogoproto/gogo.proto";
 import "google/protobuf/timestamp.proto";
 
-message ClassRevealQueueEntry {
-  google.protobuf.Timestamp reveal_time = 1 [(gogoproto.stdtime) = true, (gogoproto.nullable) = false]; 
-  string class_id = 2; 
-}
+option go_package = "github.com/likecoin/likechain/x/likenft/types";
 
+message ClassRevealQueueEntry {
+  google.protobuf.Timestamp reveal_time = 1 [
+    (gogoproto.stdtime) = true,
+    (gogoproto.nullable) = false
+  ];
+  string class_id = 2;
+}

--- a/proto/likechain/likenft/classes_by_account.proto
+++ b/proto/likechain/likenft/classes_by_account.proto
@@ -1,14 +1,15 @@
 syntax = "proto3";
+
 package likechain.likenft;
 
 option go_package = "github.com/likecoin/likechain/x/likenft/types";
 
 message ClassesByAccount {
-  string account = 1; 
-  repeated string class_ids = 2; 
+  string account = 1;
+  repeated string class_ids = 2;
 }
 
 message ClassesByAccountStoreRecord {
-  bytes acc_address = 1; 
-  repeated string class_ids = 2; 
+  bytes acc_address = 1;
+  repeated string class_ids = 2;
 }

--- a/proto/likechain/likenft/classes_by_iscn.proto
+++ b/proto/likechain/likenft/classes_by_iscn.proto
@@ -1,9 +1,10 @@
 syntax = "proto3";
+
 package likechain.likenft;
 
 option go_package = "github.com/likecoin/likechain/x/likenft/types";
 
 message ClassesByISCN {
-  string iscn_id_prefix = 1; 
-  repeated string class_ids = 2; 
+  string iscn_id_prefix = 1;
+  repeated string class_ids = 2;
 }

--- a/proto/likechain/likenft/event.proto
+++ b/proto/likechain/likenft/event.proto
@@ -1,22 +1,23 @@
 syntax = "proto3";
+
 package likechain.likenft;
 
 option go_package = "github.com/likecoin/likechain/x/likenft/types";
 
 message EventNewClass {
-  string class_id = 1; 
+  string class_id = 1;
   string parent_iscn_id_prefix = 2;
   string parent_account = 3;
 }
 
 message EventUpdateClass {
-  string class_id = 1; 
+  string class_id = 1;
   string parent_iscn_id_prefix = 2;
   string parent_account = 3;
 }
 
 message EventRevealClass {
-  string class_id = 1; 
+  string class_id = 1;
   string parent_iscn_id_prefix = 2;
   string parent_account = 3;
   bool success = 4;

--- a/proto/likechain/likenft/genesis.proto
+++ b/proto/likechain/likenft/genesis.proto
@@ -1,13 +1,15 @@
 syntax = "proto3";
+
 package likechain.likenft;
 
 import "gogoproto/gogo.proto";
-import "likechain/likenft/params.proto";
-import "likechain/likenft/classes_by_iscn.proto";
-import "likechain/likenft/classes_by_account.proto";
-import "likechain/likenft/mintable_nft.proto";
 import "likechain/likenft/class_reveal_queue.proto";
 // this line is used by starport scaffolding # genesis/proto/import
+
+import "likechain/likenft/classes_by_account.proto";
+import "likechain/likenft/classes_by_iscn.proto";
+import "likechain/likenft/mintable_nft.proto";
+import "likechain/likenft/params.proto";
 
 option go_package = "github.com/likecoin/likechain/x/likenft/types";
 

--- a/proto/likechain/likenft/mintable_nft.proto
+++ b/proto/likechain/likenft/mintable_nft.proto
@@ -1,4 +1,5 @@
 syntax = "proto3";
+
 package likechain.likenft;
 
 import "gogoproto/gogo.proto";
@@ -7,7 +8,7 @@ import "likechain/likenft/nft_input.proto";
 option go_package = "github.com/likecoin/likechain/x/likenft/types";
 
 message MintableNFT {
-  string class_id = 1; 
-  string id = 2; 
+  string class_id = 1;
+  string id = 2;
   NFTInput input = 3 [(gogoproto.nullable) = false];
 }

--- a/proto/likechain/likenft/nft_data.proto
+++ b/proto/likechain/likenft/nft_data.proto
@@ -1,4 +1,5 @@
 syntax = "proto3";
+
 package likechain.likenft;
 
 import "gogoproto/gogo.proto";

--- a/proto/likechain/likenft/nft_input.proto
+++ b/proto/likechain/likenft/nft_input.proto
@@ -1,4 +1,5 @@
 syntax = "proto3";
+
 package likechain.likenft;
 
 import "gogoproto/gogo.proto";

--- a/proto/likechain/likenft/params.proto
+++ b/proto/likechain/likenft/params.proto
@@ -1,4 +1,5 @@
 syntax = "proto3";
+
 package likechain.likenft;
 
 import "gogoproto/gogo.proto";

--- a/proto/likechain/likenft/query.proto
+++ b/proto/likechain/likenft/query.proto
@@ -1,17 +1,18 @@
 syntax = "proto3";
+
 package likechain.likenft;
 
+import "cosmos/base/query/v1beta1/pagination.proto";
+import "cosmos/nft/v1beta1/nft.proto";
 import "gogoproto/gogo.proto";
 import "google/api/annotations.proto";
-import "cosmos/base/query/v1beta1/pagination.proto";
-import "likechain/likenft/params.proto";
-import "likechain/likenft/classes_by_iscn.proto";
-import "cosmos/nft/v1beta1/nft.proto";
+import "likechain/iscn/query.proto";
 import "likechain/likenft/classes_by_account.proto";
+import "likechain/likenft/classes_by_iscn.proto";
 import "likechain/likenft/mintable_nft.proto";
 // this line is used by starport scaffolding # 1
 
-import "likechain/iscn/query.proto";
+import "likechain/likenft/params.proto";
 
 option go_package = "github.com/likecoin/likechain/x/likenft/types";
 
@@ -31,41 +32,41 @@ service Query {
     option (google.api.http).get = "/likenft/classes_by_iscn";
   }
 
-// Queries a list of ISCNByClass items.
+  // Queries a list of ISCNByClass items.
   rpc ISCNByClass(QueryISCNByClassRequest) returns (QueryISCNByClassResponse) {
     option (google.api.http).get = "/likenft/iscn_by_class/{class_id}";
   }
 
-// Queries a ClassesByAccount by index.
-	rpc ClassesByAccount(QueryClassesByAccountRequest) returns (QueryClassesByAccountResponse) {
-		option (google.api.http).get = "/likenft/classes_by_account/{account}";
-	}
+  // Queries a ClassesByAccount by index.
+  rpc ClassesByAccount(QueryClassesByAccountRequest) returns (QueryClassesByAccountResponse) {
+    option (google.api.http).get = "/likenft/classes_by_account/{account}";
+  }
 
-	// Queries a list of ClassesByAccount items.
-	rpc ClassesByAccountIndex(QueryClassesByAccountIndexRequest) returns (QueryClassesByAccountIndexResponse) {
-		option (google.api.http).get = "/likenft/classes_by_account";
-	}
+  // Queries a list of ClassesByAccount items.
+  rpc ClassesByAccountIndex(QueryClassesByAccountIndexRequest) returns (QueryClassesByAccountIndexResponse) {
+    option (google.api.http).get = "/likenft/classes_by_account";
+  }
 
-// Queries a list of AccountByClass items.
-	rpc AccountByClass(QueryAccountByClassRequest) returns (QueryAccountByClassResponse) {
-		option (google.api.http).get = "/likenft/account_by_class/{class_id}";
-	}
+  // Queries a list of AccountByClass items.
+  rpc AccountByClass(QueryAccountByClassRequest) returns (QueryAccountByClassResponse) {
+    option (google.api.http).get = "/likenft/account_by_class/{class_id}";
+  }
 
-// Queries a MintableNFT by index.
-	rpc MintableNFT(QueryMintableNFTRequest) returns (QueryMintableNFTResponse) {
-		option (google.api.http).get = "/likenft/mintable_nft/{class_id}/{id}";
-	}
+  // Queries a MintableNFT by index.
+  rpc MintableNFT(QueryMintableNFTRequest) returns (QueryMintableNFTResponse) {
+    option (google.api.http).get = "/likenft/mintable_nft/{class_id}/{id}";
+  }
 
-	// Queries a list of MintableNFT items.
-	rpc MintableNFTIndex(QueryMintableNFTIndexRequest) returns (QueryMintableNFTIndexResponse) {
-		option (google.api.http).get = "/likenft/mintable_nft";
-	}
+  // Queries a list of MintableNFT items.
+  rpc MintableNFTIndex(QueryMintableNFTIndexRequest) returns (QueryMintableNFTIndexResponse) {
+    option (google.api.http).get = "/likenft/mintable_nft";
+  }
 
-// Queries a list of MintableNFTs by class_id
-	rpc MintableNFTs(QueryMintableNFTsRequest) returns (QueryMintableNFTsResponse) {
-		option (google.api.http).get = "/likenft/mintable_nft/{class_id}";
-	}
-    
+  // Queries a list of MintableNFTs by class_id
+  rpc MintableNFTs(QueryMintableNFTsRequest) returns (QueryMintableNFTsResponse) {
+    option (google.api.http).get = "/likenft/mintable_nft/{class_id}";
+  }
+
 // this line is used by starport scaffolding # 2
 }
 
@@ -85,7 +86,7 @@ message QueryClassesByISCNRequest {
 
 message QueryClassesByISCNResponse {
   string iscn_id_prefix = 1;
-  repeated cosmos.nft.v1beta1.Class classes = 2 [(gogoproto.nullable) = false]; 
+  repeated cosmos.nft.v1beta1.Class classes = 2 [(gogoproto.nullable) = false];
   cosmos.base.query.v1beta1.PageResponse pagination = 3;
 }
 
@@ -116,17 +117,17 @@ message QueryClassesByAccountRequest {
 
 message QueryClassesByAccountResponse {
   string account = 1;
-  repeated cosmos.nft.v1beta1.Class classes = 2 [(gogoproto.nullable) = false]; 
+  repeated cosmos.nft.v1beta1.Class classes = 2 [(gogoproto.nullable) = false];
   cosmos.base.query.v1beta1.PageResponse pagination = 3;
 }
 
 message QueryClassesByAccountIndexRequest {
-	cosmos.base.query.v1beta1.PageRequest pagination = 1;
+  cosmos.base.query.v1beta1.PageRequest pagination = 1;
 }
 
 message QueryClassesByAccountIndexResponse {
-	repeated ClassesByAccount classes_by_accounts = 1 [(gogoproto.nullable) = false];
-	cosmos.base.query.v1beta1.PageResponse pagination = 2;
+  repeated ClassesByAccount classes_by_accounts = 1 [(gogoproto.nullable) = false];
+  cosmos.base.query.v1beta1.PageResponse pagination = 2;
 }
 
 message QueryAccountByClassRequest {
@@ -138,22 +139,21 @@ message QueryAccountByClassResponse {
 }
 
 message QueryMintableNFTRequest {
-	string class_id = 1;
+  string class_id = 1;
   string id = 2;
-
 }
 
 message QueryMintableNFTResponse {
-	MintableNFT mintable_nft = 1 [(gogoproto.nullable) = false];
+  MintableNFT mintable_nft = 1 [(gogoproto.nullable) = false];
 }
 
 message QueryMintableNFTIndexRequest {
-	cosmos.base.query.v1beta1.PageRequest pagination = 1;
+  cosmos.base.query.v1beta1.PageRequest pagination = 1;
 }
 
 message QueryMintableNFTIndexResponse {
-	repeated MintableNFT mintable_nfts = 1 [(gogoproto.nullable) = false];
-	cosmos.base.query.v1beta1.PageResponse pagination = 2;
+  repeated MintableNFT mintable_nfts = 1 [(gogoproto.nullable) = false];
+  cosmos.base.query.v1beta1.PageResponse pagination = 2;
 }
 
 message QueryMintableNFTsRequest {

--- a/proto/likechain/likenft/tx.proto
+++ b/proto/likechain/likenft/tx.proto
@@ -1,13 +1,13 @@
 syntax = "proto3";
+
 package likechain.likenft;
 
-import "gogoproto/gogo.proto";
 import "cosmos/nft/v1beta1/nft.proto";
+import "gogoproto/gogo.proto";
 import "likechain/likenft/class_input.proto";
 import "likechain/likenft/nft_input.proto";
 
 // this line is used by starport scaffolding # proto/tx/import
-
 option go_package = "github.com/likecoin/likechain/x/likenft/types";
 
 // Msg defines the Msg service.
@@ -19,7 +19,7 @@ service Msg {
   rpc CreateMintableNFT(MsgCreateMintableNFT) returns (MsgCreateMintableNFTResponse);
   rpc UpdateMintableNFT(MsgUpdateMintableNFT) returns (MsgUpdateMintableNFTResponse);
   rpc DeleteMintableNFT(MsgDeleteMintableNFT) returns (MsgDeleteMintableNFTResponse);
-// this line is used by starport scaffolding # proto/tx/rpc
+  // this line is used by starport scaffolding # proto/tx/rpc
 }
 
 message MsgNewClass {
@@ -59,8 +59,7 @@ message MsgBurnNFT {
   string nft_id = 3;
 }
 
-message MsgBurnNFTResponse {
-}
+message MsgBurnNFTResponse {}
 
 message MsgCreateMintableNFT {
   string creator = 1;
@@ -69,8 +68,7 @@ message MsgCreateMintableNFT {
   NFTInput input = 4 [(gogoproto.nullable) = false];
 }
 
-message MsgCreateMintableNFTResponse {
-}
+message MsgCreateMintableNFTResponse {}
 
 message MsgUpdateMintableNFT {
   string creator = 1;
@@ -79,8 +77,7 @@ message MsgUpdateMintableNFT {
   NFTInput input = 4 [(gogoproto.nullable) = false];
 }
 
-message MsgUpdateMintableNFTResponse {
-}
+message MsgUpdateMintableNFTResponse {}
 
 message MsgDeleteMintableNFT {
   string creator = 1;
@@ -88,7 +85,6 @@ message MsgDeleteMintableNFT {
   string id = 3;
 }
 
-message MsgDeleteMintableNFTResponse {
-}
+message MsgDeleteMintableNFTResponse {}
 
 // this line is used by starport scaffolding # proto/tx/message

--- a/scripts/gen_proto.sh
+++ b/scripts/gen_proto.sh
@@ -26,7 +26,7 @@ for module in "${MODULES[@]}"; do
       --gocosmos_out=plugins=interfacetype+grpc,Mgoogle/protobuf/any.proto=github.com/cosmos/cosmos-sdk/codec/types:. \
       --grpc-gateway_out=logtostderr=true:. \
       --proto_path proto \
-      ./proto/${module}/* \
+      ./proto/likechain/${module}/* \
       --swagger_out ${SWAGGER_DIR} \
       --swagger_opt logtostderr=true --swagger_opt fqn_for_swagger_name=true --swagger_opt simple_operation_ids=true
 

--- a/x/likenft/keeper/classes_by_account_test.go
+++ b/x/likenft/keeper/classes_by_account_test.go
@@ -43,7 +43,7 @@ func TestClassesByAccountGet(t *testing.T) {
 func TestClassesByAccountRemove(t *testing.T) {
 	keeper, ctx := keepertest.LikenftKeeper(t)
 	items, accounts := createNClassesByAccount(keeper, ctx, 10)
-	for i, _ := range items {
+	for i := range items {
 		keeper.RemoveClassesByAccount(ctx,
 			accounts[i],
 		)


### PR DESCRIPTION
Ref oursky/likecoin-chain#213 

- fix proto source path in gen_proto.sh
- adopt `buf format` at `make proto-format`
- add ci step to check format
- fix existing proto files

should cherrypick into 169 for submitting ci changes to upstream