### PR TITLE
Upgrade ibc-go to v2.3.0; Add chain v3 migration

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -86,7 +86,6 @@ import (
 	ibcclient "github.com/cosmos/ibc-go/v2/modules/core/02-client"
 	ibcclientclient "github.com/cosmos/ibc-go/v2/modules/core/02-client/client"
 	ibcclienttypes "github.com/cosmos/ibc-go/v2/modules/core/02-client/types"
-	ibcconnectiontypes "github.com/cosmos/ibc-go/v2/modules/core/03-connection/types"
 	porttypes "github.com/cosmos/ibc-go/v2/modules/core/05-port/types"
 	ibchost "github.com/cosmos/ibc-go/v2/modules/core/24-host"
 	ibckeeper "github.com/cosmos/ibc-go/v2/modules/core/keeper"
@@ -94,11 +93,6 @@ import (
 	"github.com/likecoin/likecoin-chain/v2/x/iscn"
 	iscnkeeper "github.com/likecoin/likecoin-chain/v2/x/iscn/keeper"
 	iscntypes "github.com/likecoin/likecoin-chain/v2/x/iscn/types"
-
-	bech32authmigration "github.com/likecoin/likecoin-chain/v2/bech32-migration/auth"
-	bech32govmigration "github.com/likecoin/likecoin-chain/v2/bech32-migration/gov"
-	bech32slashingmigration "github.com/likecoin/likecoin-chain/v2/bech32-migration/slashing"
-	bech32stakingmigration "github.com/likecoin/likecoin-chain/v2/bech32-migration/staking"
 )
 
 var (
@@ -512,32 +506,34 @@ func NewLikeApp(
 
 // Upgrade Handler
 func (app *LikeApp) registerUpgradeHandlers() {
-	app.UpgradeKeeper.SetUpgradeHandler("v2.0.0", func(ctx sdk.Context, plan upgradetypes.Plan, _ module.VersionMap) (module.VersionMap, error) {
-		app.IBCKeeper.ConnectionKeeper.SetParams(ctx, ibcconnectiontypes.DefaultParams())
+	app.UpgradeKeeper.SetUpgradeHandler("v3.0.0", func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		// Migration for ibc-go v2.1.0 to v2.3.0: Support base denoms with slashes
+		// Ref: https://github.com/cosmos/ibc-go/blob/main/docs/migrations/support-denoms-with-slashes.md
 
-		ctx.Logger().Info("First step: Migrate sdk modules")
-		// using 1 as fromVersion to avoid running InitGenesis for existing modules
-		// note newer sdk already guarantees auth module is migrated last
-		fromVM := make(map[string]uint64)
-		for moduleName := range app.mm.Modules {
-			fromVM[moduleName] = 1
+		// list of traces that must replace the old traces in store
+		var newTraces []ibctransfertypes.DenomTrace
+		equalTraces := func(dtA, dtB ibctransfertypes.DenomTrace) bool {
+			return dtA.BaseDenom == dtB.BaseDenom && dtA.Path == dtB.Path
 		}
-		// exclude new modules to not skip InitGenesis
-		delete(fromVM, authz.ModuleName)
-		delete(fromVM, feegrant.ModuleName)
-		// run
-		newVM, err := app.mm.RunMigrations(ctx, app.configurator, fromVM)
-		if err != nil {
-			return nil, err
+		app.TransferKeeper.IterateDenomTraces(ctx,
+			func(dt ibctransfertypes.DenomTrace) bool {
+				// check if the new way of splitting FullDenom
+				// into Trace and BaseDenom passes validation and
+				// is the same as the current DenomTrace.
+				// If it isn't then store the new DenomTrace in the list of new traces.
+				newTrace := ibctransfertypes.ParseDenomTrace(dt.GetFullDenomPath())
+				if err := newTrace.Validate(); err == nil && !equalTraces(newTrace, dt) {
+					newTraces = append(newTraces, newTrace)
+				}
+				return false
+			})
+
+		// replace the outdated traces with the new trace information
+		for _, nt := range newTraces {
+			app.TransferKeeper.SetDenomTrace(ctx, nt)
 		}
 
-		ctx.Logger().Info("Second step: Migrate addresses stored in bech32 form to use new prefix")
-		bech32stakingmigration.MigrateAddressBech32(ctx, app.keys[stakingtypes.StoreKey], app.appCodec)
-		bech32slashingmigration.MigrateAddressBech32(ctx, app.keys[slashingtypes.StoreKey], app.appCodec)
-		bech32govmigration.MigrateAddressBech32(ctx, app.keys[govtypes.StoreKey], app.appCodec)
-		bech32authmigration.MigrateAddressBech32(ctx, app.keys[authtypes.StoreKey], app.appCodec)
-
-		return newVM, nil
+		return app.mm.RunMigrations(ctx, app.configurator, fromVM)
 	})
 
 	upgradeInfo, err := app.UpgradeKeeper.ReadUpgradeInfoFromDisk()
@@ -545,9 +541,10 @@ func (app *LikeApp) registerUpgradeHandlers() {
 		panic(err)
 	}
 
-	if upgradeInfo.Name == "v2.0.0" && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
+	if upgradeInfo.Name == "v3.0.0" && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
 		storeUpgrades := storetypes.StoreUpgrades{
-			Added: []string{authz.ModuleName, feegrant.ModuleName},
+			// TODO: register x/nft and x/likenft here after rebase
+			// Added: []string{},
 		}
 
 		// configure store loader that checks if version == upgradeHeight and applies store upgrades

--- a/app/app.go
+++ b/app/app.go
@@ -90,9 +90,9 @@ import (
 	ibchost "github.com/cosmos/ibc-go/v2/modules/core/24-host"
 	ibckeeper "github.com/cosmos/ibc-go/v2/modules/core/keeper"
 
-	"github.com/likecoin/likecoin-chain/v2/x/iscn"
-	iscnkeeper "github.com/likecoin/likecoin-chain/v2/x/iscn/keeper"
-	iscntypes "github.com/likecoin/likecoin-chain/v2/x/iscn/types"
+	"github.com/likecoin/likecoin-chain/v3/x/iscn"
+	iscnkeeper "github.com/likecoin/likecoin-chain/v3/x/iscn/keeper"
+	iscntypes "github.com/likecoin/likecoin-chain/v3/x/iscn/types"
 )
 
 var (

--- a/bech32-migration/auth/auth.go
+++ b/bech32-migration/auth/auth.go
@@ -7,7 +7,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/auth/types"
 	vestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
 
-	"github.com/likecoin/likecoin-chain/v2/bech32-migration/utils"
+	"github.com/likecoin/likecoin-chain/v3/bech32-migration/utils"
 )
 
 func MigrateAddressBech32(ctx sdk.Context, storeKey sdk.StoreKey, cdc codec.BinaryCodec) {

--- a/bech32-migration/gov/gov.go
+++ b/bech32-migration/gov/gov.go
@@ -8,7 +8,7 @@ import (
 	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	"github.com/cosmos/cosmos-sdk/x/gov/types"
 
-	"github.com/likecoin/likecoin-chain/v2/bech32-migration/utils"
+	"github.com/likecoin/likecoin-chain/v3/bech32-migration/utils"
 )
 
 func MigrateAddressBech32(ctx sdk.Context, storeKey sdk.StoreKey, cdc codec.BinaryCodec) {

--- a/bech32-migration/slashing/slashing.go
+++ b/bech32-migration/slashing/slashing.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/x/slashing/types"
 
-	"github.com/likecoin/likecoin-chain/v2/bech32-migration/utils"
+	"github.com/likecoin/likecoin-chain/v3/bech32-migration/utils"
 )
 
 func MigrateAddressBech32(ctx sdk.Context, storeKey sdk.StoreKey, cdc codec.BinaryCodec) {

--- a/bech32-migration/staking/staking.go
+++ b/bech32-migration/staking/staking.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/x/staking/types"
 
-	"github.com/likecoin/likecoin-chain/v2/bech32-migration/utils"
+	"github.com/likecoin/likecoin-chain/v3/bech32-migration/utils"
 )
 
 func MigrateAddressBech32(ctx sdk.Context, storeKey sdk.StoreKey, cdc codec.BinaryCodec) {

--- a/bech32-migration/test/migrate.go
+++ b/bech32-migration/test/migrate.go
@@ -10,19 +10,19 @@ import (
 	"github.com/cosmos/cosmos-sdk/server/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/crisis"
-	"github.com/likecoin/likecoin-chain/v2/testutil"
+	"github.com/likecoin/likecoin-chain/v3/testutil"
 
-	bech32migrationtestutil "github.com/likecoin/likecoin-chain/v2/bech32-migration/testutil"
+	bech32migrationtestutil "github.com/likecoin/likecoin-chain/v3/bech32-migration/testutil"
 
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
-	bech32authmigration "github.com/likecoin/likecoin-chain/v2/bech32-migration/auth"
-	bech32govmigration "github.com/likecoin/likecoin-chain/v2/bech32-migration/gov"
-	bech32slashingmigration "github.com/likecoin/likecoin-chain/v2/bech32-migration/slashing"
-	bech32stakingmigration "github.com/likecoin/likecoin-chain/v2/bech32-migration/staking"
+	bech32authmigration "github.com/likecoin/likecoin-chain/v3/bech32-migration/auth"
+	bech32govmigration "github.com/likecoin/likecoin-chain/v3/bech32-migration/gov"
+	bech32slashingmigration "github.com/likecoin/likecoin-chain/v3/bech32-migration/slashing"
+	bech32stakingmigration "github.com/likecoin/likecoin-chain/v3/bech32-migration/staking"
 )
 
 type MTAppOptions struct{}

--- a/bech32-migration/testutil/auth.go
+++ b/bech32-migration/testutil/auth.go
@@ -10,7 +10,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/auth/types"
 	vestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
 
-	"github.com/likecoin/likecoin-chain/v2/bech32-migration/utils"
+	"github.com/likecoin/likecoin-chain/v3/bech32-migration/utils"
 )
 
 func AssertAuthAddressBech32(ctx sdk.Context, storeKey sdk.StoreKey, cdc codec.BinaryCodec) bool {

--- a/bech32-migration/testutil/gov.go
+++ b/bech32-migration/testutil/gov.go
@@ -10,7 +10,7 @@ import (
 	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	"github.com/cosmos/cosmos-sdk/x/gov/types"
 
-	"github.com/likecoin/likecoin-chain/v2/bech32-migration/utils"
+	"github.com/likecoin/likecoin-chain/v3/bech32-migration/utils"
 )
 
 func AssertGovAddressBech32(ctx sdk.Context, storeKey sdk.StoreKey, cdc codec.BinaryCodec) bool {

--- a/bech32-migration/testutil/slashing.go
+++ b/bech32-migration/testutil/slashing.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/x/slashing/types"
 
-	"github.com/likecoin/likecoin-chain/v2/bech32-migration/utils"
+	"github.com/likecoin/likecoin-chain/v3/bech32-migration/utils"
 )
 
 func AssertSlashingAddressBech32(ctx sdk.Context, storeKey sdk.StoreKey, cdc codec.BinaryCodec) bool {

--- a/bech32-migration/testutil/staking.go
+++ b/bech32-migration/testutil/staking.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/x/staking/types"
 
-	"github.com/likecoin/likecoin-chain/v2/bech32-migration/utils"
+	"github.com/likecoin/likecoin-chain/v3/bech32-migration/utils"
 )
 
 func AssertStakingAddressBech32(ctx sdk.Context, storeKey sdk.StoreKey, cdc codec.BinaryCodec) bool {

--- a/cmd/liked/cmd/cmd.go
+++ b/cmd/liked/cmd/cmd.go
@@ -14,7 +14,7 @@ import (
 	"github.com/tendermint/tendermint/libs/log"
 	dbm "github.com/tendermint/tm-db"
 
-	"github.com/likecoin/likecoin-chain/v2/app"
+	"github.com/likecoin/likecoin-chain/v3/app"
 
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -44,7 +44,7 @@ import (
 
 	simappcli "github.com/cosmos/cosmos-sdk/simapp/simd/cmd"
 
-	"github.com/likecoin/likecoin-chain/v2/ip"
+	"github.com/likecoin/likecoin-chain/v3/ip"
 
 	serverconfig "github.com/cosmos/cosmos-sdk/server/config"
 )

--- a/cmd/liked/main.go
+++ b/cmd/liked/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/likecoin/likecoin-chain/v2/cmd/liked/cmd"
+import "github.com/likecoin/likecoin-chain/v3/cmd/liked/cmd"
 
 func main() {
 	cmd.Execute()

--- a/dual_prefix_tests/bank_test.go
+++ b/dual_prefix_tests/bank_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/likecoin/likecoin-chain/v2/testutil"
+	"github.com/likecoin/likecoin-chain/v3/testutil"
 	"github.com/stretchr/testify/require"
 
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"

--- a/dual_prefix_tests/iscn_test.go
+++ b/dual_prefix_tests/iscn_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/likecoin/likecoin-chain/v2/testutil"
-	iscntypes "github.com/likecoin/likecoin-chain/v2/x/iscn/types"
+	"github.com/likecoin/likecoin-chain/v3/testutil"
+	iscntypes "github.com/likecoin/likecoin-chain/v3/x/iscn/types"
 	"github.com/stretchr/testify/require"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/likecoin/likecoin-chain/v2
 go 1.18
 
 require (
-	github.com/cosmos/cosmos-sdk v0.44.8
+	github.com/cosmos/cosmos-sdk v0.45.5
 	github.com/cosmos/ibc-go/v2 v2.1.0
 	github.com/gogo/protobuf v1.3.3
 	github.com/golang/protobuf v1.5.2

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/likecoin/likecoin-chain/v2
+module github.com/likecoin/likecoin-chain/v3
 
 go 1.18
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/cosmos/cosmos-sdk v0.45.5
-	github.com/cosmos/ibc-go/v2 v2.1.0
+	github.com/cosmos/ibc-go/v2 v2.3.0
 	github.com/gogo/protobuf v1.3.3
 	github.com/golang/protobuf v1.5.2
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -140,7 +140,6 @@ github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQ
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bits-and-blooms/bitset v1.2.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edYb8uY+O0FJTyyDA=
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
-github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqOes/6LfM=
 github.com/btcsuite/btcd v0.0.0-20171128150713-2e60448ffcc6/go.mod h1:Dmm/EzmjnCiweXmzRIAiUWCInVmPgjkzgv5k4tVyXiQ=
 github.com/btcsuite/btcd v0.0.0-20190115013929-ed77733ec07d/go.mod h1:d3C0AkH6BRcvO8T0UEPu53cnw4IbV63x1bEjildYhO0=
 github.com/btcsuite/btcd v0.0.0-20190315201642-aa6e0f35703c/go.mod h1:DrZx5ec/dmnfpw9KyYoQyYo7d0KEvTkk/5M/vbZjAr8=
@@ -219,8 +218,8 @@ github.com/cosmos/go-bip39 v1.0.0 h1:pcomnQdrdH22njcAatO0yWojsUnCO3y2tNoV1cb6hHY
 github.com/cosmos/go-bip39 v1.0.0/go.mod h1:RNJv0H/pOIVgxw6KS7QeX2a0Uo0aKUlfhZ4xuwvCdJw=
 github.com/cosmos/iavl v0.17.3 h1:s2N819a2olOmiauVa0WAhoIJq9EhSXE9HDBAoR9k+8Y=
 github.com/cosmos/iavl v0.17.3/go.mod h1:prJoErZFABYZGDHka1R6Oay4z9PrNeFFiMKHDAMOi4w=
-github.com/cosmos/ibc-go/v2 v2.1.0 h1:+tV7cvT4rA+MyiHF8lZn60V0zpYa4mAFPifc74Qzt/4=
-github.com/cosmos/ibc-go/v2 v2.1.0/go.mod h1:v3DgNy4Uh+6znWqG1eAqjrpouZn8jozUDdg2Z+4WeH0=
+github.com/cosmos/ibc-go/v2 v2.3.0 h1:/+j8i83NsPjdepsefPAMs1YcFtD531Z7I/X6WWpe204=
+github.com/cosmos/ibc-go/v2 v2.3.0/go.mod h1:cS41UWIsZXjrOuqYWKuzLZhIgn95QUpdCB0prV/ZLdk=
 github.com/cosmos/keyring v1.1.7-0.20210622111912-ef00f8ac3d76 h1:DdzS1m6o/pCqeZ8VOAit/gyATedRgjvkVI+UCrLpyuU=
 github.com/cosmos/keyring v1.1.7-0.20210622111912-ef00f8ac3d76/go.mod h1:0mkLWIoZuQ7uBoospo5Q9zIpqq6rYCPJDSUdeCJvPM8=
 github.com/cosmos/ledger-cosmos-go v0.11.1 h1:9JIYsGnXP613pb2vPjFeMMjBI5lEDsEaF6oYorTy6J4=
@@ -446,7 +445,6 @@ github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5m
 github.com/googleapis/gax-go/v2 v2.1.0/go.mod h1:Q3nei7sK6ybPYH7twZdmQpAd1MKb7pfu6SK+H1/DsU0=
 github.com/googleapis/gax-go/v2 v2.1.1/go.mod h1:hddJymUZASv3XPyGkUpKj8pPO47Rmb0eJc8R6ouapiM=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
-github.com/gordonklaus/ineffassign v0.0.0-20200309095847-7953dde2c7bf/go.mod h1:cuNKsD1zp2v6XfE/orVX2QE1LC+i254ceGcVeDT3pTU=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/handlers v1.5.1 h1:9lRY6j8DEeeBT10CvO9hGW0gmky0BprnvDI5vfhUHH4=
 github.com/gorilla/handlers v1.5.1/go.mod h1:t8XrUpc4KVXb7HGyJ4/cEnwQiaxrX/hz1Zv/4g96P1Q=
@@ -552,7 +550,6 @@ github.com/jedisct1/go-minisign v0.0.0-20190909160543-45766022959e/go.mod h1:G1C
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jhump/protoreflect v1.9.0 h1:npqHz788dryJiR/l6K/RUQAyh2SwV91+d1dnh4RjO9w=
-github.com/jhump/protoreflect v1.9.0/go.mod h1:7GcYQDdMU/O/BBrl/cX6PNHpXh6cenjd8pneu5yW7Tg=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
@@ -666,7 +663,6 @@ github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0Qu
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.3.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
-github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.4.2/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.4.3 h1:OVowDSCllw/YjdLkam3/sm7wEtOy59d8ndGgCcyj8cs=
 github.com/mitchellh/mapstructure v1.4.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
@@ -720,7 +716,6 @@ github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OS
 github.com/neilotoole/errgroup v0.1.5/go.mod h1:Q2nLGf+594h0CLBs/Mbg6qOr7GtqDK7C2S41udRnToE=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/nishanths/predeclared v0.0.0-20200524104333-86fad755b4d3/go.mod h1:nt3d53pc1VYcphSCIaYAJtnPYnr3Zyn8fMq2wvPGPso=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
@@ -736,7 +731,6 @@ github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108
 github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/ginkgo v1.16.2/go.mod h1:CObGmKUOKaSC0RjmoAK7tKyn4Azo5P2IWuoMnvwxz1E=
 github.com/onsi/ginkgo v1.16.4 h1:29JGrr5oVBm5ulCWet69zQkzWipVXIol6ygQUe/EzNc=
-github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
 github.com/onsi/gomega v1.4.1/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
@@ -769,11 +763,6 @@ github.com/openzipkin/zipkin-go v0.2.5/go.mod h1:KpXfKdgRDnnhsxw4pNIH9Md5lyFqKUa
 github.com/ory/dockertest v3.3.5+incompatible h1:iLLK6SQwIhcbrG783Dghaaa3WPzGc+4Emza6EbVUUGA=
 github.com/ory/dockertest v3.3.5+incompatible/go.mod h1:1vX4m9wsvi00u5bseYwXaSnhNrne+V0E6LAcBILJdPs=
 github.com/otiai10/copy v1.6.0 h1:IinKAryFFuPONZ7cm6T6E2QX/vcJwSnlaA5lfoaXIiQ=
-github.com/otiai10/copy v1.6.0/go.mod h1:XWfuS3CrI0R6IE0FbgHsEazaXO8G0LpMp9o8tos0x4E=
-github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
-github.com/otiai10/curr v1.0.0/go.mod h1:LskTG5wDwr8Rs+nNQ+1LlxRjAtTZZjtJW4rMXl6j4vs=
-github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
-github.com/otiai10/mint v1.3.2/go.mod h1:/yxELlJQ0ufhjUwhshSj+wFjZ78CnZ48/1wtmBH1OTc=
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=
@@ -781,7 +770,6 @@ github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144T
 github.com/pborman/uuid v0.0.0-20170112150404-1b00554d8222/go.mod h1:VyrYX9gd7irzKovcSS6BIIEwPRkP2Wm2m9ufcdFSJ34=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
-github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml v1.9.4 h1:tjENF6MfZAg8e4ZmZTeWaWiT2vXtsoO6+iuOjFhECwM=
 github.com/pelletier/go-toml v1.9.4/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/performancecopilot/speed v3.0.0+incompatible/go.mod h1:/CLtqpZ5gBg1M9iaPbIdPPGyKcA8hKdoy6hAWba7Yac=
@@ -901,14 +889,12 @@ github.com/spf13/afero v1.3.3/go.mod h1:5KUK8ByomD5Ti5Artl0RtHeI5pTF7MIDuXL3yY52
 github.com/spf13/afero v1.6.0 h1:xoax2sJ2DT8S8xA2paPFjDCScCNeWsg75VG0DLRreiY=
 github.com/spf13/afero v1.6.0/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
-github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cast v1.4.1 h1:s0hze+J0196ZfEMTs80N7UlFt0BDuQ7Q+JDnHiMWKdA=
 github.com/spf13/cast v1.4.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
 github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/cobra v1.1.1/go.mod h1:WnodtKOvamDL/PwE2M4iKs8aMDBZ5Q5klgD3qfVJQMI=
-github.com/spf13/cobra v1.2.1/go.mod h1:ExllRjgxM/piMAM+3tAZvg8fsklGAf3tPfi+i8t68Nk=
 github.com/spf13/cobra v1.4.0 h1:y+wJpx64xcgO1V+RcnwW0LEHxTKRi2ZDPSBjWnrg88Q=
 github.com/spf13/cobra v1.4.0/go.mod h1:Wo4iy3BUC+X2Fybo0PDqwJIv3dNRiZLHQymsfxlB84g=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
@@ -922,7 +908,6 @@ github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DM
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
 github.com/spf13/viper v1.7.1/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
-github.com/spf13/viper v1.8.1/go.mod h1:o0Pch8wJ9BVSWGQMbra6iw0oQ5oktSIBaujf1rJH9Ns=
 github.com/spf13/viper v1.10.1 h1:nuJZuYpG7gTj/XqiUwg8bA0cp1+M2mC3J4g5luUYBKk=
 github.com/spf13/viper v1.10.1/go.mod h1:IGlFPqhNAPKRxohIzWpI5QEy4kuI7tcl5WvR+8qy1rU=
 github.com/status-im/keycard-go v0.0.0-20190316090335-8537d3370df4/go.mod h1:RZLeN1LMWmRsyYjvAu+I6Dm9QmlDaIIt+Y+4Kd7Tp+Q=
@@ -1181,7 +1166,6 @@ golang.org/x/oauth2 v0.0.0-20201208152858-08078c50e5b5/go.mod h1:KelEdhl1UZF7XfJ
 golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210220000619-9bb904979d93/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210313182246-cd4f82c27b84/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
-golang.org/x/oauth2 v0.0.0-20210402161424-2e8d93401602/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210628180205-a41e5a781914/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210805134026-6f1e6394065a/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
@@ -1361,10 +1345,8 @@ golang.org/x/tools v0.0.0-20200331025713-a30bf2db82d4/go.mod h1:Sl4aGygMT6LrqrWc
 golang.org/x/tools v0.0.0-20200501065659-ab2804fb9c9d/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200512131952-2bc93b1c0c88/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200515010526-7d3b6ebf133d/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
-golang.org/x/tools v0.0.0-20200522201501-cb1345f3a375/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200618134242-20370b0cb4b2/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
-golang.org/x/tools v0.0.0-20200717024301-6ddee64345a6/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200729194436-6467de6f59a7/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200804011535-6c149bb5ef0d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
@@ -1413,7 +1395,6 @@ google.golang.org/api v0.36.0/go.mod h1:+z5ficQTmoYpPn8LCUNVpK5I7hwkpjbcgqA7I34q
 google.golang.org/api v0.40.0/go.mod h1:fYKFpnQN0DsDSKRVRcQSDQNtqWPfM9i+zNPxepjRCQ8=
 google.golang.org/api v0.41.0/go.mod h1:RkxM5lITDfTzmyKFPt+wGrCJbVfniCr2ool8kTBzRTU=
 google.golang.org/api v0.43.0/go.mod h1:nQsDGjRXMo4lvh5hP0TKqF244gqhGcr/YSIykhUk/94=
-google.golang.org/api v0.44.0/go.mod h1:EBOGZqzyhtvMDoxwS97ctnh0zUmYY6CxqXsc1AvkYD8=
 google.golang.org/api v0.47.0/go.mod h1:Wbvgpq1HddcWVtzsVLyfLp8lDg6AA241LmgIL59tHXo=
 google.golang.org/api v0.48.0/go.mod h1:71Pr1vy+TAZRPkPs/xlCf5SsU8WjuAWv1Pfjbtukyy4=
 google.golang.org/api v0.50.0/go.mod h1:4bNT5pAuq5ji4SRZm+5QIkjny9JAyVD/3gaSihNefaw=
@@ -1515,7 +1496,6 @@ google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
-google.golang.org/protobuf v1.25.1-0.20200805231151-a709e31e5d12/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
@@ -1532,8 +1512,6 @@ gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/gcfg.v1 v1.2.3/go.mod h1:yesOnuUOFQAhST5vPY4nbZsb/huCgGGXlipJsBn0b3o=
 gopkg.in/ini.v1 v1.51.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
-gopkg.in/ini.v1 v1.62.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
-gopkg.in/ini.v1 v1.63.2/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/ini.v1 v1.66.2 h1:XfR1dOYubytKy4Shzc2LHrrGhU0lDCfDGG1yLPmpgsI=
 gopkg.in/ini.v1 v1.66.2/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce/go.mod h1:5AcXVHNjg+BDxry382+8OKon8SEWiKktQR07RKPsv1c=

--- a/ibc_tests/transfer_test.go
+++ b/ibc_tests/transfer_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	likeapp "github.com/likecoin/likecoin-chain/v2/app"
+	likeapp "github.com/likecoin/likecoin-chain/v3/app"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/tendermint/tendermint/libs/log"

--- a/proto/iscn/genesis.proto
+++ b/proto/iscn/genesis.proto
@@ -4,7 +4,7 @@ package likechain.iscn;
 import "gogoproto/gogo.proto";
 import "iscn/params.proto";
 
-option go_package = "github.com/likecoin/likecoin-chain/v2/x/iscn/types";
+option go_package = "github.com/likecoin/likecoin-chain/v3/x/iscn/types";
 
 message GenesisState {
   message ContentIdRecord {

--- a/proto/iscn/iscnid.proto
+++ b/proto/iscn/iscnid.proto
@@ -3,7 +3,7 @@ package likechain.iscn;
 
 import "gogoproto/gogo.proto";
 
-option go_package = "github.com/likecoin/likecoin-chain/v2/x/iscn/types";
+option go_package = "github.com/likecoin/likecoin-chain/v3/x/iscn/types";
 
 message IscnIdPrefix {
   option (gogoproto.equal)            = true;

--- a/proto/iscn/params.proto
+++ b/proto/iscn/params.proto
@@ -4,7 +4,7 @@ package likechain.iscn;
 import "gogoproto/gogo.proto";
 import "cosmos/base/v1beta1/coin.proto";
 
-option go_package = "github.com/likecoin/likecoin-chain/v2/x/iscn/types";
+option go_package = "github.com/likecoin/likecoin-chain/v3/x/iscn/types";
 
 message Params {
   option (gogoproto.equal)            = false;

--- a/proto/iscn/query.proto
+++ b/proto/iscn/query.proto
@@ -5,7 +5,7 @@ import "gogoproto/gogo.proto";
 import "google/api/annotations.proto";
 import "iscn/params.proto";
 
-option go_package = "github.com/likecoin/likecoin-chain/v2/x/iscn/types";
+option go_package = "github.com/likecoin/likecoin-chain/v3/x/iscn/types";
 
 service Query {
   // Usage:

--- a/proto/iscn/store.proto
+++ b/proto/iscn/store.proto
@@ -4,7 +4,7 @@ package likechain.iscn;
 import "gogoproto/gogo.proto";
 import "iscn/iscnid.proto";
 
-option go_package = "github.com/likecoin/likecoin-chain/v2/x/iscn/types";
+option go_package = "github.com/likecoin/likecoin-chain/v3/x/iscn/types";
 
 message StoreRecord {
   IscnId iscn_id = 1 [

--- a/proto/iscn/tx.proto
+++ b/proto/iscn/tx.proto
@@ -3,7 +3,7 @@ package likechain.iscn;
 
 import "gogoproto/gogo.proto";
 
-option go_package = "github.com/likecoin/likecoin-chain/v2/x/iscn/types";
+option go_package = "github.com/likecoin/likecoin-chain/v3/x/iscn/types";
 
 // Msg defines the bank Msg service.
 service Msg {

--- a/scripts/gen_proto.sh
+++ b/scripts/gen_proto.sh
@@ -28,7 +28,7 @@ for module in "${MODULES[@]}"; do
       --swagger_out ${SWAGGER_DIR} \
       --swagger_opt logtostderr=true --swagger_opt fqn_for_swagger_name=true --swagger_opt simple_operation_ids=true
 
-    mv github.com/likecoin/likecoin-chain/v2/x/${module}/types/* x/${module}/types/
+    mv github.com/likecoin/likecoin-chain/v3/x/${module}/types/* x/${module}/types/
 done
 
 popd > /dev/null 2>&1

--- a/testutil/network/network.go
+++ b/testutil/network/network.go
@@ -17,7 +17,7 @@ import (
 	tmrand "github.com/tendermint/tendermint/libs/rand"
 	tmdb "github.com/tendermint/tm-db"
 
-	"github.com/likecoin/likecoin-chain/v2/app"
+	"github.com/likecoin/likecoin-chain/v3/app"
 )
 
 type (

--- a/testutil/testing_app.go
+++ b/testutil/testing_app.go
@@ -23,9 +23,9 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	crisistypes "github.com/cosmos/cosmos-sdk/x/crisis/types"
 
-	likeapp "github.com/likecoin/likecoin-chain/v2/app"
+	likeapp "github.com/likecoin/likecoin-chain/v3/app"
 
-	"github.com/likecoin/likecoin-chain/v2/x/iscn/types"
+	"github.com/likecoin/likecoin-chain/v3/x/iscn/types"
 )
 
 const DefaultNodeHome = "/tmp/.liked-test"

--- a/x/iscn/app_test.go
+++ b/x/iscn/app_test.go
@@ -15,10 +15,10 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	crisistypes "github.com/cosmos/cosmos-sdk/x/crisis/types"
 
-	"github.com/likecoin/likecoin-chain/v2/x/iscn/keeper"
-	"github.com/likecoin/likecoin-chain/v2/x/iscn/types"
+	"github.com/likecoin/likecoin-chain/v3/x/iscn/keeper"
+	"github.com/likecoin/likecoin-chain/v3/x/iscn/types"
 
-	testutil "github.com/likecoin/likecoin-chain/v2/testutil"
+	testutil "github.com/likecoin/likecoin-chain/v3/testutil"
 )
 
 var (

--- a/x/iscn/client/cli/query.go
+++ b/x/iscn/client/cli/query.go
@@ -10,7 +10,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/version"
 
-	"github.com/likecoin/likecoin-chain/v2/x/iscn/types"
+	"github.com/likecoin/likecoin-chain/v3/x/iscn/types"
 )
 
 const (

--- a/x/iscn/client/cli/tx.go
+++ b/x/iscn/client/cli/tx.go
@@ -14,7 +14,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/version"
 
-	"github.com/likecoin/likecoin-chain/v2/x/iscn/types"
+	"github.com/likecoin/likecoin-chain/v3/x/iscn/types"
 )
 
 func NewTxCmd() *cobra.Command {

--- a/x/iscn/handler.go
+++ b/x/iscn/handler.go
@@ -4,8 +4,8 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
-	"github.com/likecoin/likecoin-chain/v2/x/iscn/keeper"
-	"github.com/likecoin/likecoin-chain/v2/x/iscn/types"
+	"github.com/likecoin/likecoin-chain/v3/x/iscn/keeper"
+	"github.com/likecoin/likecoin-chain/v3/x/iscn/types"
 )
 
 func NewHandler(k keeper.Keeper) sdk.Handler {

--- a/x/iscn/keeper/alias.go
+++ b/x/iscn/keeper/alias.go
@@ -1,7 +1,7 @@
 package keeper
 
 import (
-	"github.com/likecoin/likecoin-chain/v2/x/iscn/types"
+	"github.com/likecoin/likecoin-chain/v3/x/iscn/types"
 )
 
 type (

--- a/x/iscn/keeper/genesis.go
+++ b/x/iscn/keeper/genesis.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/likecoin/likecoin-chain/v2/x/iscn/types"
+	"github.com/likecoin/likecoin-chain/v3/x/iscn/types"
 )
 
 func (k Keeper) InitGenesis(ctx sdk.Context, genesis *types.GenesisState) {

--- a/x/iscn/keeper/grpc_query.go
+++ b/x/iscn/keeper/grpc_query.go
@@ -8,7 +8,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	"github.com/likecoin/likecoin-chain/v2/x/iscn/types"
+	"github.com/likecoin/likecoin-chain/v3/x/iscn/types"
 )
 
 const FingerprintRecordsPageLimit = 100

--- a/x/iscn/keeper/invariants.go
+++ b/x/iscn/keeper/invariants.go
@@ -13,7 +13,7 @@ import (
 
 	gocid "github.com/ipfs/go-cid"
 
-	"github.com/likecoin/likecoin-chain/v2/x/iscn/types"
+	"github.com/likecoin/likecoin-chain/v3/x/iscn/types"
 )
 
 const (

--- a/x/iscn/keeper/keeper.go
+++ b/x/iscn/keeper/keeper.go
@@ -11,7 +11,7 @@ import (
 	authTypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	paramTypes "github.com/cosmos/cosmos-sdk/x/params/types"
 
-	"github.com/likecoin/likecoin-chain/v2/x/iscn/types"
+	"github.com/likecoin/likecoin-chain/v3/x/iscn/types"
 )
 
 type AccountKeeper interface {

--- a/x/iscn/keeper/msg_server.go
+++ b/x/iscn/keeper/msg_server.go
@@ -6,7 +6,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
-	"github.com/likecoin/likecoin-chain/v2/x/iscn/types"
+	"github.com/likecoin/likecoin-chain/v3/x/iscn/types"
 )
 
 type msgServer struct {

--- a/x/iscn/module.go
+++ b/x/iscn/module.go
@@ -16,9 +16,9 @@ import (
 	"github.com/spf13/cobra"
 	abci "github.com/tendermint/tendermint/abci/types"
 
-	"github.com/likecoin/likecoin-chain/v2/x/iscn/client/cli"
-	"github.com/likecoin/likecoin-chain/v2/x/iscn/keeper"
-	"github.com/likecoin/likecoin-chain/v2/x/iscn/types"
+	"github.com/likecoin/likecoin-chain/v3/x/iscn/client/cli"
+	"github.com/likecoin/likecoin-chain/v3/x/iscn/keeper"
+	"github.com/likecoin/likecoin-chain/v3/x/iscn/types"
 )
 
 var (


### PR DESCRIPTION
Ref oursky/likecoin-chain#309 oursky/likecoin-chain#305 

- Specify cosmos-sdk at v0.45.5 at go mod require list (previous pr only updated the replace list)
- Cross-checked replace list with sdk go mod
- Upgrade ibc-go to v2.3.0
- Cross-checked upstream ibc transfer test case not changed
- Add migration logic for chain v3.0.0: for ibc-go (ref https://github.com/cosmos/ibc-go/blob/main/docs/migrations/support-denoms-with-slashes.md), & added todo to register x/nft and x/likenft when rebase
- Bump go module version suffix to v3
